### PR TITLE
Define Layer Order based on Geometry Type

### DIFF
--- a/src/components/MapInterface/Map/SourceAndLayers/SourceAndLayers.tsx
+++ b/src/components/MapInterface/Map/SourceAndLayers/SourceAndLayers.tsx
@@ -30,6 +30,13 @@ export const SourceAndLayers: React.FC = () => {
   // Therefore, we look at a flattened topics list for this component.
   const configTopics = flatConfigTopics(configThemesTopics)
 
+  const layerOrder = {
+    symbol: 'housenumber',
+    circle: 'housenumber',
+    line: 'place-hamlet',
+    fill: 'waterway',
+    heatmap: 'waterway',
+  }
   return (
     <>
       {configTopics.map((topicConfig) => {
@@ -93,11 +100,11 @@ export const SourceAndLayers: React.FC = () => {
                     source: sourceId,
                     sourceLayer: layer['source-layer'],
                   }).find((l) => l.type === layer.type)?.paint
-
                 const layerProps = {
                   id: layerId,
                   type: layer.type,
                   source: sourceId,
+                  beforeId: layerOrder[layer.type],
                   'source-layer': layer['source-layer'],
                   layout: layout,
                   filter: filter,

--- a/src/components/MapInterface/Map/SourceAndLayers/SourceAndLayers.tsx
+++ b/src/components/MapInterface/Map/SourceAndLayers/SourceAndLayers.tsx
@@ -33,9 +33,9 @@ export const SourceAndLayers: React.FC = () => {
   const layerOrder = {
     symbol: 'housenumber',
     circle: 'housenumber',
-    line: 'place-hamlet',
-    fill: 'waterway',
-    heatmap: 'waterway',
+    line: 'boundary_country',
+    fill: 'landuse',
+    heatmap: 'landuse',
   }
   return (
     <>


### PR DESCRIPTION
This PR defines the `beforId` for each custom layer we add. The `beforeId` is inferred based on the geometry type of the layer.