### PR TITLE
Maproulette API and Inspector Campaign-Hints

### DIFF
--- a/src/app/api/maproulette/[projectKey]/_utils/maprouletteProjects.const.ts
+++ b/src/app/api/maproulette/[projectKey]/_utils/maprouletteProjects.const.ts
@@ -1,0 +1,5 @@
+export const maprouletteProjects = [
+  'adjoiningOrIsolated',
+  'advisoryOrExclusive',
+  'needsClarification',
+] as const

--- a/src/app/api/maproulette/[projectKey]/_utils/taskMarkdown.ts
+++ b/src/app/api/maproulette/[projectKey]/_utils/taskMarkdown.ts
@@ -1,0 +1,107 @@
+import { LineString } from '@turf/helpers'
+import { translations } from 'src/app/regionen/[regionSlug]/_components/SidebarInspector/TagsTable/translations/translations.const'
+import {
+  longOsmType,
+  mapillaryUrl,
+} from 'src/app/regionen/[regionSlug]/_components/SidebarInspector/Tools/osmUrls/osmUrls'
+import { pointFromGeometry } from 'src/app/regionen/[regionSlug]/_components/SidebarInspector/Tools/osmUrls/pointFromGeometry'
+import { maprouletteProjects } from './maprouletteProjects.const'
+
+type MapRouletteProjectKey = (typeof maprouletteProjects)[number]
+type Props = {
+  projectKey: MapRouletteProjectKey
+  id: string
+  type: string
+  category: string
+  geometry: LineString
+}
+
+export const categoryToMaprouletteProjectKey = (category: string) => {
+  if (category.includes('adjoiningOrIsolated')) {
+    return 'adjoiningOrIsolated' as MapRouletteProjectKey
+  }
+  if (category.includes('advisoryOrExclusive')) {
+    return 'advisoryOrExclusive' as MapRouletteProjectKey
+  }
+  if (category === 'needsClarification') {
+    return 'needsClarification' as MapRouletteProjectKey
+  }
+  return undefined
+}
+
+export const taskDescriptionMarkdown = ({ projectKey, id, type, category, geometry }: Props) => {
+  const [lng, lat] = pointFromGeometry(geometry)
+  const categoryTranslated = translations[`ALL--category=${category}`]
+    ?.replace('(Straßenbegleitend oder selbstständig geführt; Kategorisierung unklar)', '')
+    ?.replace('(Kategorisierung unklar)', '')
+    ?.trim()
+
+  // Do not add indentation, it will break the Markdown in Maproulette
+  // Use in Maproulette as `{task_markdown}`
+  return (() => {
+    switch (projectKey) {
+      case 'adjoiningOrIsolated':
+        return `
+## Kontext
+
+Für diese Infrastruktur (${categoryTranslated}) fehlt uns eine Angabe ob sie straßenbegleitend ist (oder nicht).
+
+## Aufgabe
+
+Bitte präzisiere das Tagging.
+* Ist die Infrastruktur ein Gehweg? Dann wähle "Gehweg" als Typ aus oder füge \`footway=sidepath\` hinzu.
+* Ist die Infrastruktur ein Radweg oder geteilter/gemeinsamer Geh- und Radweg? Dann ergänze bitte \`is_sidepath=yes\` wenn der Weg straßenbegleitend ist oder \`is_sidepath=no\` für selbständig/frei geführt Wege.
+
+## Hilfsmittel
+
+* [Mapillary-Link zu dieser Stelle](${mapillaryUrl(geometry, 3)})
+* [Radverkehrsatlas an dieser Stelle](https://radverkehrsatlas.de/regionen/deutschland?map=13/${lat}/${lng})
+* [OpenStreetMap](https://www.openstreetmap.org/${longOsmType[type]}/${id})
+
+`
+      case 'advisoryOrExclusive':
+        return `
+## Kontext
+
+Für diese Infrastruktur fehlen uns Angaben, um sie als Schutzstreifen oder Radfahrstreifen einzutragen.
+
+## Aufgabe
+
+Bitte präzisiere das Tagging.
+* Für Schutzstreifen, füge \`cycleway:lane=advisory\` hinzu.
+* Für Radfahrstreifen, füge \`cycleway:lane=exclusive\` hinzu.
+* [Mehr im OSM Wiki…](https://wiki.openstreetmap.org/wiki/Key:cycleway:lane)
+
+## Hilfsmittel
+
+* [Mapillary-Link zu dieser Stelle](${mapillaryUrl(geometry, 3)})
+* [Radverkehrsatlas an dieser Stelle](https://radverkehrsatlas.de/regionen/deutschland?map=13/${lat}/${lng})
+* [OpenStreetMap](https://www.openstreetmap.org/${longOsmType[type]}/${id})
+
+`
+      case 'needsClarification':
+        return `
+## Kontext
+
+Diese Radinfrastruktur konnte nicht richtig kategorisiert werden.
+Es ist ein \`highway=cycleway\` oder ein \`highway=path+bicycle=designated\` ohne weitere Attribute.
+
+## Aufgabe
+
+Bitte präzisiere das Tagging.
+* Ist es ein Übergang an einer Straße? Füge \`cycleway=crossing\` oder \`path=crossing\` hinzu.
+* Ist es ein Verbindungsstück das nur für das Routing relevant ist? Füge \`cycleway=link\` hinzu.
+* Wenn möglich, ergänze bitte auch \`is_sidepath=yes|no\` um anzuzeigen, ob die Infrastruktur straßenbegleitend (\`yes\`) oder selbständig geführt (\`no\`) ist (bzw. bei Gehwegen stattdessen \`footway=sidepath\`).
+* Wenn möglich, ergänze bitte auch das Verkehrszeichen ([Tagging-Hilfe](https://trafficsigns.osm-verkehrswende.org/)).
+* Wenn du ein aussagekräftiges Foto in Mapillary siehst, füge es als \`mapillary=IMAGE_KEY\` hinzu.
+
+## Hilfsmittel
+
+* [Mapillary-Link zu dieser Stelle](${mapillaryUrl(geometry, 3)})
+* [Radverkehrsatlas an dieser Stelle](https://radverkehrsatlas.de/regionen/deutschland?map=13/${lat}/${lng})
+* [OpenStreetMap](https://www.openstreetmap.org/${longOsmType[type]}/${id})
+
+`
+    }
+  })()
+}

--- a/src/app/api/maproulette/[projectKey]/route.ts
+++ b/src/app/api/maproulette/[projectKey]/route.ts
@@ -1,0 +1,104 @@
+import { Prisma } from '@prisma/client'
+import * as turf from '@turf/turf'
+import { LineString } from '@turf/turf'
+import { NextRequest } from 'next/server'
+import { isProd } from 'src/app/_components/utils/isEnv'
+import { longOsmType } from 'src/app/regionen/[regionSlug]/_components/SidebarInspector/Tools/osmUrls/osmUrls'
+import { prismaClientForRawQueries } from 'src/prisma-client'
+import { z } from 'zod'
+import { maprouletteProjects } from './_utils/maprouletteProjects.const'
+import { taskDescriptionMarkdown } from './_utils/taskMarkdown'
+
+const idType = z.coerce.bigint().positive()
+const MaprouletteSchema = z.object({
+  projectKey: z.enum(maprouletteProjects),
+  ids: z.union([z.array(idType), idType.transform((x) => [x])]),
+})
+
+export async function GET(request: NextRequest, { params }: { params: { projectKey: string } }) {
+  let parsedParams: z.infer<typeof MaprouletteSchema>
+  const searchParams = request.nextUrl.searchParams
+  try {
+    parsedParams = MaprouletteSchema.parse({
+      ids: searchParams.getAll('ids'),
+      projectKey: params.projectKey,
+    })
+  } catch (e) {
+    if (!isProd) throw e
+    Response.status(400).send('Bad Request')
+    return
+  }
+
+  try {
+    // PREPARE
+    const { projectKey, ids } = parsedParams
+    await prismaClientForRawQueries.$queryRaw`SET search_path TO public`
+
+    // CHECK REGIONS (`ids` params)
+    const nHits = await prismaClientForRawQueries.$executeRaw`
+      SELECT osm_id FROM boundaries WHERE osm_id IN (${Prisma.join(ids)})`
+    if (nHits !== ids.length) {
+      Response.status(404).send("Couldn't find given ids. At least one id is wrong or dupplicated.")
+      return
+    }
+
+    // SELECT WAYS FROM DB
+    const wherePart = (() => {
+      switch (projectKey) {
+        case 'adjoiningOrIsolated':
+          return Prisma.sql`bikelanes.tags->>'category' LIKE '%adjoiningOrIsolated'`
+        case 'advisoryOrExclusive':
+          return Prisma.sql`bikelanes.tags->>'category' LIKE '%advisoryOrExclusive'`
+        case 'needsClarification':
+          return Prisma.sql`bikelanes.tags->>'category' = 'needsClarification'`
+      }
+    })()
+
+    type QueryTpye = { type: string; id: string; category: string; geometry: LineString }[]
+    const sqlWays = await prismaClientForRawQueries.$queryRaw<QueryTpye>`
+      SELECT
+        bikelanes.osm_type as type,
+        bikelanes.osm_id as id,
+        bikelanes.tags->'category' AS category,
+        ST_AsGeoJSON(ST_Transform(bikelanes.geom, 4326))::jsonb AS geometry
+      FROM public.bikelanes_verified as bikelanes,
+        (
+          SELECT ST_Union(boundaries.geom) as union_geom
+          FROM public.boundaries as boundaries
+          WHERE boundaries.osm_id IN (${Prisma.join(ids)})
+        ) as subquery
+      WHERE
+        ${wherePart}
+        AND ST_intersects(subquery.union_geom, bikelanes.geom);
+    `
+
+    // ADD MAPROULETTE TASK DATA
+    const features = sqlWays.map(({ type, id, category, geometry }) => {
+      const properties = {
+        id: `${longOsmType[type]}/${id}`,
+        category,
+        task_updated_at: new Date().toISOString(), // can be used in MapRoulette to see if/when data was fetched
+        task_markdown: taskDescriptionMarkdown({
+          projectKey,
+          id,
+          type,
+          category,
+          geometry,
+        }).replaceAll('\n', ' \n'),
+      }
+      // Create feature and also shorten lat/lng values to 8 digits
+      return turf.truncate(turf.feature(geometry, properties), { precision: 8 })
+    })
+
+    // RESPONSE
+    const featureCollection = turf.featureCollection(features)
+    return Response.json(featureCollection, {
+      headers: {
+        'Content-Disposition': `attachment; filename="maproulette_${projectKey}.geojson"`,
+      },
+    })
+  } catch (e) {
+    if (!isProd) throw e
+    return Response.status(500).send('Internal Server Error')
+  }
+}

--- a/src/app/regionen/[regionSlug]/_components/SidebarInspector/InspectorFeatureSource.tsx
+++ b/src/app/regionen/[regionSlug]/_components/SidebarInspector/InspectorFeatureSource.tsx
@@ -1,7 +1,13 @@
+import { LineString } from '@turf/turf'
 import React from 'react'
 import { FormattedMessage, IntlProvider } from 'react-intl'
-import { extractSourceIdIdFromSourceKey } from '../Map/SourcesAndLayers/utils/extractFromSourceKey/extractFromKey'
+import { Markdown } from 'src/app/_components/text/Markdown'
+import {
+  categoryToMaprouletteProjectKey,
+  taskDescriptionMarkdown,
+} from 'src/app/api/maproulette/[projectKey]/_utils/taskMarkdown'
 import { getSourceData } from '../../_mapData/utils/getMapDataUtils'
+import { extractSourceIdIdFromSourceKey } from '../Map/SourcesAndLayers/utils/extractFromSourceKey/extractFromKey'
 import { Disclosure } from './Disclosure/Disclosure'
 import { InspectorDataFeature } from './Inspector'
 import { MapillaryIframe } from './MapillaryIframe/MapillaryIframe'
@@ -28,6 +34,8 @@ export const InspectorFeatureSource: React.FC<InspectorDataFeature> = ({
   if (!sourceData.inspector.enabled) return null
   if (!sourceTranslationKey) return null
 
+  const maprouletteProjectKey = categoryToMaprouletteProjectKey(properties.category)
+
   return (
     <div className="mt-5 w-full rounded-2xl bg-white">
       <IntlProvider messages={translations} locale="de" defaultLocale="de">
@@ -37,7 +45,9 @@ export const InspectorFeatureSource: React.FC<InspectorDataFeature> = ({
         >
           {properties.prefix && (
             <details className="prose prose-sm bg-purple-100 p-1 px-4 py-1.5">
-              <summary>Hinweis: Transformierte Geometrie</summary>
+              <summary className="cursor-pointer hover:font-semibold">
+                Hinweis: Transformierte Geometrie
+              </summary>
               <p className="my-0 ml-3">
                 Diese Geometrie wurde im Rahmen der Datenaufbereitung künstlich erstellt. In
                 OpenStreetMap sind die Daten an der Straßen-Geometrie erfasst. Durch die
@@ -45,6 +55,25 @@ export const InspectorFeatureSource: React.FC<InspectorDataFeature> = ({
                 Sie sorgt aber auch dafür, dass Verbindungspunkte kleine Kanten und Lücken aufweisen
                 können.
               </p>
+            </details>
+          )}
+          {maprouletteProjectKey && (
+            <details className="prose prose-sm border-t border-white bg-purple-100 p-1 px-4 py-1.5">
+              <summary className="cursor-pointer hover:font-semibold">
+                Kampagne zur Datenverbesserung
+              </summary>
+              <div className="my-0 ml-3 py-3">
+                <Markdown
+                  markdown={taskDescriptionMarkdown({
+                    projectKey: maprouletteProjectKey,
+                    id: properties.osm_id,
+                    type: properties.osm_type,
+                    category: properties.category,
+                    geometry: geometry as LineString,
+                  })}
+                  className="prose-sm marker:text-purple-700"
+                />
+              </div>
             </details>
           )}
 

--- a/src/app/regionen/[regionSlug]/_components/SidebarInspector/Tools/osmUrls/osmUrls.tsx
+++ b/src/app/regionen/[regionSlug]/_components/SidebarInspector/Tools/osmUrls/osmUrls.tsx
@@ -16,11 +16,25 @@ export const historyUrl = (type: OsmShortType, id: number | string) => {
   return `https://osmlab.github.io/osm-deep-history/#/${longOsmType[type]}/${id}`
 }
 
-export const mapillaryUrl = (geometry: maplibregl.GeoJSONFeature['geometry']) => {
+export const mapillaryUrl = (
+  geometry: maplibregl.GeoJSONFeature['geometry'],
+  yearsAgo?: number,
+) => {
   const [lng, lat] = pointFromGeometry(geometry)
   if (!lng || !lat) return undefined
 
-  return `https://www.mapillary.com/app/?lat=${lat}&lng=${lng}&z=15`
+  const url = new URL('https://www.mapillary.com/app/')
+  url.searchParams.set('lat', lat.toString())
+  url.searchParams.set('lng', lng.toString())
+  url.searchParams.set('z', '15')
+  if (yearsAgo) {
+    url.searchParams.set(
+      'dateFrom',
+      new Date(new Date().setFullYear(new Date().getFullYear() - 2)).toISOString().slice(0, 10),
+    )
+  }
+
+  return url.toString()
 }
 
 export const mapillaryKeyUrl = (key: number) => {


### PR DESCRIPTION
This introduces a way to create API endpoints that can be used in MapRoulette to create Projects/Campaigns to improve certain data categories. The geojson that is creates has a `task_markdown` field that can be used in MapRoulette as dynamic task description. The same text is reused in the Inspector to give a hint on what to do to update the data. The wording is a bit off there, because it is mainly meant to be used in Maproulette.

Ping https://github.com/FixMyBerlin/private-issues/issues/1364