### PR TITLE
Add Function Layers for Generalization

### DIFF
--- a/src/app/regionen/[regionSlug]/_mapData/mapDataSources/sources.const.ts
+++ b/src/app/regionen/[regionSlug]/_mapData/mapDataSources/sources.const.ts
@@ -57,6 +57,10 @@ export type SourceExportApiIdentifier = (typeof exportApiIdentifier)[number]
 export const exportFunctionIdentifier = <TId extends SourceExportApiIdentifier>(tableName: TId) =>
   `atlas_export_geojson_${tableName.toLowerCase()}` as `atlas_export_geojson_${Lowercase<TId>}`
 
+export const generalizationFunctionIdentifier = <TId extends SourceExportApiIdentifier>(
+  tableName: TId,
+) => `atlas_generalization_${tableName.toLowerCase()}` as `atlas_generalization_${Lowercase<TId>}`
+
 // https://account.mapbox.com/access-tokens
 // "Default public token"
 const apiKeyMapbox =

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -4,6 +4,7 @@ import {
 } from 'src/app/regionen/[regionSlug]/_mapData/mapDataSources/sources.const'
 import { initExportFunctions } from './instrumentation/initExportFunctions'
 import { initVerificationViews } from './instrumentation/initVerificationViews'
+import { initGeneralizationFunctions } from './instrumentation/initGeneralizationFunctions'
 
 // This function gets called on every server startup. For details see /src/instrumentation/README.md
 export async function register() {
@@ -11,6 +12,7 @@ export async function register() {
     try {
       await initVerificationViews(verificationApiIdentifier)
       await initExportFunctions(exportApiIdentifier)
+      await initGeneralizationFunctions(['roads'])
     } catch (e) {
       console.error('\n\nINSTRUMENTATION HOOK FAILED', e)
     }

--- a/src/instrumentation/initExportFunctions.ts
+++ b/src/instrumentation/initExportFunctions.ts
@@ -8,7 +8,7 @@ const attribution = "'OpenStreetMap, https://www.openstreetmap.org/copyright; Ra
 export async function initExportFunctions(tables) {
   return Promise.all(
     tables.map((tableName) => {
-      const functionName = exportFunctionIdentifier(tableName.toLowerCase())
+      const functionName = exportFunctionIdentifier(tableName)
 
       return prismaClientForRawQueries.$transaction([
         prismaClientForRawQueries.$executeRaw`SET search_path TO public;`,
@@ -19,9 +19,9 @@ export async function initExportFunctions(tables) {
           AS $function$
           SELECT
           json_build_object(
-            'type', 'FeatureCollection', 
+            'type', 'FeatureCollection',
             'license', ${license},
-            'attribution', ${attribution}, 
+            'attribution', ${attribution},
             'features', json_agg(features.feature)
           )
           FROM(

--- a/src/instrumentation/initGeneralizationFunctions.ts
+++ b/src/instrumentation/initGeneralizationFunctions.ts
@@ -48,8 +48,8 @@ export async function initGeneralizationFunctions(tables) {
                     4096, 64, true) AS g
               FROM "${tableName}"
               WHERE (geom && ST_TileEnvelope(z, x, y))
-                and (not tags?'_minZoom' or z >= (tags->'_minZoom')::integer)
-                and (not tags?'_maxZoom' or z < (tags->'_maxZoom')::integer)
+                and (not tags?'_minzoom' or z >= (tags->'_minzoom')::integer)
+                and (not tags?'_maxzoom' or z < (tags->'_maxzoom')::integer)
             ) AS tile WHERE geom IS NOT NULL;
             RETURN mvt;
           END

--- a/src/instrumentation/initGeneralizationFunctions.ts
+++ b/src/instrumentation/initGeneralizationFunctions.ts
@@ -47,7 +47,9 @@ export async function initGeneralizationFunctions(tables) {
                     ST_TileEnvelope(z, x, y),
                     4096, 64, true) AS g
               FROM "${tableName}"
-              WHERE (geom && ST_TileEnvelope(z, x, y)) and (not tags?'_minZoom' or z >= (tags->'_minZoom')::integer )
+              WHERE (geom && ST_TileEnvelope(z, x, y))
+                and (not tags?'_minZoom' or z >= (tags->'_minZoom')::integer)
+                and (not tags?'_maxZoom' or z < (tags->'_maxZoom')::integer)
             ) AS tile WHERE geom IS NOT NULL;
             RETURN mvt;
           END

--- a/src/instrumentation/initGeneralizationFunctions.ts
+++ b/src/instrumentation/initGeneralizationFunctions.ts
@@ -1,0 +1,46 @@
+import { generalizationFunctionIdentifier } from 'src/app/regionen/[regionSlug]/_mapData/mapDataSources/sources.const'
+import { prismaClientForRawQueries } from 'src/prisma-client'
+import { Prisma } from '@prisma/client'
+
+// specify license and attribution for data export
+export async function initGeneralizationFunctions(tables) {
+  return Promise.all(
+    tables.map(async (tableName) => {
+      const functionName = generalizationFunctionIdentifier(tableName)
+      // Get table columns and types for vector tile specification (tile.json)
+      const queryResults = await prismaClientForRawQueries.$queryRawUnsafe(`
+        SELECT jsonb_object_agg(column_name, udt_name) - 'geom' as fields
+          FROM information_schema.columns
+          WHERE table_schema = 'public' AND table_name = '${tableName}';`)
+      const { fields } = queryResults && queryResults[0]
+      const vectorLayerDescriptions = { vector_layers: [{ id: functionName, fields }] }
+      return prismaClientForRawQueries.$transaction([
+        prismaClientForRawQueries.$executeRaw`SET search_path TO public;`,
+        prismaClientForRawQueries.$executeRawUnsafe(
+          `CREATE OR REPLACE
+          FUNCTION public.${functionName}(z integer, x integer, y integer)
+          RETURNS bytea AS $$
+          DECLARE
+            mvt bytea;
+          BEGIN
+            SELECT INTO mvt ST_AsMVT(tile, '${functionName}', 4096, 'g') FROM (
+              select
+              *,
+                ST_AsMVTGeom(
+                    geom,
+                    ST_TileEnvelope(z, x, y),
+                    4096, 64, true) AS g
+              FROM "${tableName}"
+              WHERE (geom && ST_TileEnvelope(z, x, y)) and (not tags?'_minZoom' or z >= (tags->'_minZoom')::integer )
+            ) as tile WHERE geom IS NOT NULL;
+            RETURN mvt;
+          END
+          $$ LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE;`,
+        ),
+        prismaClientForRawQueries.$executeRawUnsafe(
+          `COMMENT ON FUNCTION ${functionName} IS '${JSON.stringify(vectorLayerDescriptions)}';`,
+        ),
+      ])
+    }),
+  )
+}

--- a/src/instrumentation/initGeneralizationFunctions.ts
+++ b/src/instrumentation/initGeneralizationFunctions.ts
@@ -7,13 +7,29 @@ export async function initGeneralizationFunctions(tables) {
   return Promise.all(
     tables.map(async (tableName) => {
       const functionName = generalizationFunctionIdentifier(tableName)
-      // Get table columns and types for vector tile specification (tile.json)
-      const queryResults = await prismaClientForRawQueries.$queryRawUnsafe(`
-        SELECT jsonb_object_agg(column_name, udt_name) - 'geom' as fields
+      // Gather meta information for the tile specification
+
+      // Get column names and types
+      const columnInformation = await prismaClientForRawQueries.$queryRawUnsafe(`
+        SELECT jsonb_object_agg(column_name, udt_name) - 'geom' AS fields
           FROM information_schema.columns
           WHERE table_schema = 'public' AND table_name = '${tableName}';`)
-      const { fields } = queryResults && queryResults[0]
-      const vectorLayerDescriptions = { vector_layers: [{ id: functionName, fields }] }
+      const { fields } = columnInformation && columnInformation[0]
+
+      // Get the geometric extent
+      const bbox = await prismaClientForRawQueries.$queryRawUnsafe(
+        `SELECT ST_XMIN(bbox) AS xmin, ST_YMIN(bbox) AS ymin, ST_XMAX(bbox) AS xmax, ST_YMAX(bbox) AS ymax
+          from (
+            SELECT ST_Transform(ST_SetSRID(ST_Extent(geom), 3857), 4326) AS bbox
+              from ${tableName}
+            ) extent;`,
+      )
+      const { xmin, ymin, xmax, ymax } = bbox && bbox[0]
+      // format as vector tile specifaction
+      const tileSpecification = {
+        vector_layers: [{ id: functionName, fields }],
+        bounds: [xmin, ymin, xmax, ymax],
+      }
       return prismaClientForRawQueries.$transaction([
         prismaClientForRawQueries.$executeRaw`SET search_path TO public;`,
         prismaClientForRawQueries.$executeRawUnsafe(
@@ -32,13 +48,13 @@ export async function initGeneralizationFunctions(tables) {
                     4096, 64, true) AS g
               FROM "${tableName}"
               WHERE (geom && ST_TileEnvelope(z, x, y)) and (not tags?'_minZoom' or z >= (tags->'_minZoom')::integer )
-            ) as tile WHERE geom IS NOT NULL;
+            ) AS tile WHERE geom IS NOT NULL;
             RETURN mvt;
           END
           $$ LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE;`,
         ),
         prismaClientForRawQueries.$executeRawUnsafe(
-          `COMMENT ON FUNCTION ${functionName} IS '${JSON.stringify(vectorLayerDescriptions)}';`,
+          `COMMENT ON FUNCTION ${functionName} IS '${JSON.stringify(tileSpecification)}';`,
         ),
       ])
     }),


### PR DESCRIPTION
This PR adds a function layer for the `roads` data set, which filters the displayed geometries based on the `_minZoom` and `_maxZoom` values. For now it's only activated for the `roads` data but it can be easily extended to other data.