### PR TITLE
Tune Performance of Generalization Function

### DIFF
--- a/src/app/regionen/[regionSlug]/_mapData/mapDataSources/sources.const.ts
+++ b/src/app/regionen/[regionSlug]/_mapData/mapDataSources/sources.const.ts
@@ -54,7 +54,14 @@ export const exportFunctionIdentifier = <TId extends SourceExportApiIdentifier>(
 
 export const generalizationFunctionIdentifier = <TId extends SourceExportApiIdentifier>(
   tableName: TId,
-) => `atlas_generalization_${tableName.toLowerCase()}` as `atlas_generalization_${Lowercase<TId>}`
+) => `atlas_generalized_${tableName.toLowerCase()}` as `atlas_generalized_${Lowercase<TId>}`
+
+export type InteracitvityConfiguartion = Partial<
+  Record<SourceExportApiIdentifier, { minzoom: number; stylingKeys: string[] }>
+>
+export const interacitvityConfiguartion: InteracitvityConfiguartion = {
+  roads: { stylingKeys: ['road'], minzoom: 9 },
+}
 
 // https://account.mapbox.com/access-tokens
 // "Default public token"

--- a/src/app/regionen/[regionSlug]/_mapData/mapDataSources/sources.const.ts
+++ b/src/app/regionen/[regionSlug]/_mapData/mapDataSources/sources.const.ts
@@ -163,7 +163,7 @@ export const sources: MapDataSource<
   },
   {
     id: 'atlas_bikelanes',
-    tiles: `${tilesUrl}/bikelanes/{z}/{x}/{y}`,
+    tiles: `${tilesUrl}/atlas_generalized_bikelanes/{z}/{x}/{y}`,
     maxzoom: 12,
     minzoom: 4,
     attributionHtml:
@@ -246,7 +246,7 @@ export const sources: MapDataSource<
   },
   {
     id: 'atlas_roads',
-    tiles: `${tilesUrl}/roads/{z}/{x}/{y}`,
+    tiles: `${tilesUrl}/atlas_generalized_roads/{z}/{x}/{y}`,
     maxzoom: 14,
     minzoom: 8,
     attributionHtml:

--- a/src/app/regionen/[regionSlug]/_mapData/mapDataSources/sources.const.ts
+++ b/src/app/regionen/[regionSlug]/_mapData/mapDataSources/sources.const.ts
@@ -61,6 +61,10 @@ export type InteracitvityConfiguartion = Partial<
 >
 export const interacitvityConfiguartion: InteracitvityConfiguartion = {
   roads: { stylingKeys: ['road'], minzoom: 9 },
+  bikelanes: {
+    stylingKeys: ['category', 'osm_separation:left', 'surface', 'width', 'smoothness'],
+    minzoom: 9,
+  },
 }
 
 // https://account.mapbox.com/access-tokens

--- a/src/app/regionen/[regionSlug]/_mapData/mapDataSources/sources.const.ts
+++ b/src/app/regionen/[regionSlug]/_mapData/mapDataSources/sources.const.ts
@@ -48,6 +48,7 @@ export type SourcesId =
 export const verificationApiIdentifier = ['bikelanes'] as const
 export type SourceVerificationApiIdentifier = (typeof verificationApiIdentifier)[number]
 
+// TODO: this is also redundant, it gets defined again in `sources` with `export.enabled`
 // Define the export tables
 export const exportApiIdentifier = [
   'bicycleParking_points',

--- a/src/app/regionen/[regionSlug]/_mapData/mapDataSources/sources.const.ts
+++ b/src/app/regionen/[regionSlug]/_mapData/mapDataSources/sources.const.ts
@@ -2,6 +2,26 @@ import { getTilesUrl } from 'src/app/_components/utils/getTilesUrl'
 import { MapDataSource } from '../types'
 import { sourcesParking, SourcesParkingId } from './sourcesParking.const'
 
+// this type includes all tables we generate in atlas-geo
+// TODO: automatically generate this in atlas-geo
+export type TableId =
+  | 'barrierLines'
+  | 'barrierAreas'
+  | 'bicycleParking_points'
+  | 'bicycleParking_areas'
+  | 'bikeroutes'
+  | 'boundaries'
+  | 'boundaryLabels'
+  | 'presenceStats'
+  | 'landuse'
+  | 'places'
+  | 'poiClassification'
+  | 'publicTransport'
+  | 'roads'
+  | 'roadsPathClasses'
+  | 'bikelanes'
+  | 'trafficSigns'
+
 // TODO type MapDataConfigSourcesIds = typeof sources[number]['id']
 export type SourcesId =
   | SourcesParkingId
@@ -52,12 +72,11 @@ export type SourceExportApiIdentifier = (typeof exportApiIdentifier)[number]
 export const exportFunctionIdentifier = <TId extends SourceExportApiIdentifier>(tableName: TId) =>
   `atlas_export_geojson_${tableName.toLowerCase()}` as `atlas_export_geojson_${Lowercase<TId>}`
 
-export const generalizationFunctionIdentifier = <TId extends SourceExportApiIdentifier>(
-  tableName: TId,
-) => `atlas_generalized_${tableName.toLowerCase()}` as `atlas_generalized_${Lowercase<TId>}`
+export const generalizationFunctionIdentifier = (tableName: TableId) =>
+  `atlas_generalized_${tableName.toLowerCase()}` as `atlas_generalized_${Lowercase<TableId>}`
 
 export type InteracitvityConfiguartion = Partial<
-  Record<SourceExportApiIdentifier, { minzoom: number; stylingKeys: string[] }>
+  Record<TableId, { minzoom: number; stylingKeys: string[] }>
 >
 export const interacitvityConfiguartion: InteracitvityConfiguartion = {
   roads: { stylingKeys: ['road'], minzoom: 9 },

--- a/src/app/regionen/[regionSlug]/_mapData/mapDataSources/sources.const.ts
+++ b/src/app/regionen/[regionSlug]/_mapData/mapDataSources/sources.const.ts
@@ -81,7 +81,7 @@ export type InteracitvityConfiguartion = Partial<
 export const interacitvityConfiguartion: InteracitvityConfiguartion = {
   roads: { stylingKeys: ['road'], minzoom: 9 },
   bikelanes: {
-    stylingKeys: ['category', 'osm_separation:left', 'surface', 'width', 'smoothness'],
+    stylingKeys: ['category', 'surface', 'width', 'smoothness'],
     minzoom: 9,
   },
 }

--- a/src/app/regionen/[regionSlug]/_mapData/mapDataSources/sources.const.ts
+++ b/src/app/regionen/[regionSlug]/_mapData/mapDataSources/sources.const.ts
@@ -48,7 +48,6 @@ export type SourcesId =
 export const verificationApiIdentifier = ['bikelanes'] as const
 export type SourceVerificationApiIdentifier = (typeof verificationApiIdentifier)[number]
 
-// TODO: this is also redundant, it gets defined again in `sources` with `export.enabled`
 // Define the export tables
 export const exportApiIdentifier = [
   'bicycleParking_points',

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,4 +1,8 @@
-import { exportApiIdentifier } from 'src/app/regionen/[regionSlug]/_mapData/mapDataSources/sources.const'
+import {
+  exportApiIdentifier,
+  interacitvityConfiguartion,
+} from 'src/app/regionen/[regionSlug]/_mapData/mapDataSources/sources.const'
+import { initCustomFunctions } from './instrumentation/initCustomFunctions'
 import { initExportFunctions } from './instrumentation/initExportFunctions'
 import { initGeneralizationFunctions } from './instrumentation/initGeneralizationFunctions'
 
@@ -6,8 +10,9 @@ import { initGeneralizationFunctions } from './instrumentation/initGeneralizatio
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
     try {
+      await initCustomFunctions()
       await initExportFunctions(exportApiIdentifier)
-      await initGeneralizationFunctions(['roads'])
+      await initGeneralizationFunctions(interacitvityConfiguartion)
     } catch (e) {
       console.error('\n\nINSTRUMENTATION HOOK FAILED', e)
     }

--- a/src/instrumentation/initCustomFunctions.ts
+++ b/src/instrumentation/initCustomFunctions.ts
@@ -1,0 +1,25 @@
+import { prismaClientForRawQueries } from 'src/prisma-client'
+
+// specify license and attribution for data export
+export async function initCustomFunctions() {
+  const queries = prismaClientForRawQueries.$transaction([
+    prismaClientForRawQueries.$executeRaw`
+  CREATE OR REPLACE FUNCTION public.jsonb_select(json_in JSONB, keys text[])
+  RETURNS JSONB AS $$
+  DECLARE
+      json_out JSONB := '{}';
+       key text;
+  BEGIN
+      FOREACH key IN ARRAY keys
+      loop
+        IF json_in ? key THEN
+            json_out := json_out || jsonb_build_object(key, json_in -> key);
+          END IF;
+      END LOOP;
+      RETURN json_out;
+  END;
+  $$ LANGUAGE plpgsql;
+  `,
+  ])
+  return queries
+}

--- a/src/instrumentation/initGeneralizationFunctions.ts
+++ b/src/instrumentation/initGeneralizationFunctions.ts
@@ -63,7 +63,7 @@ export async function initGeneralizationFunctions(tables) {
               FROM "${tableName}"
               WHERE (geom && ST_TileEnvelope(z, x, y))
                 and  z >= minzoom
-            ) AS tile WHERE geom IS NOT NULL;
+            ) AS tile;
             RETURN mvt;
           END
           $$ LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE;`,

--- a/src/instrumentation/initGeneralizationFunctions.ts
+++ b/src/instrumentation/initGeneralizationFunctions.ts
@@ -18,17 +18,17 @@ export async function initGeneralizationFunctions(tables) {
 
       // Get the geometric extent
       const bbox = await prismaClientForRawQueries.$queryRawUnsafe(
-        `SELECT ST_XMIN(bbox) AS xmin, ST_YMIN(bbox) AS ymin, ST_XMAX(bbox) AS xmax, ST_YMAX(bbox) AS ymax
+        `SELECT Array[ST_XMIN(bbox),ST_YMIN(bbox),ST_XMAX(bbox),ST_YMAX(bbox)] as bounds
           from (
             SELECT ST_Transform(ST_SetSRID(ST_Extent(geom), 3857), 4326) AS bbox
               from ${tableName}
             ) extent;`,
       )
-      const { xmin, ymin, xmax, ymax } = bbox && bbox[0]
+      const { bounds } = bbox && bbox[0]
       // format as vector tile specifaction
       const tileSpecification = {
         vector_layers: [{ id: functionName, fields }],
-        bounds: [xmin, ymin, xmax, ymax],
+        bounds,
       }
       return prismaClientForRawQueries.$transaction([
         prismaClientForRawQueries.$executeRaw`SET search_path TO public;`,

--- a/src/instrumentation/initGeneralizationFunctions.ts
+++ b/src/instrumentation/initGeneralizationFunctions.ts
@@ -38,12 +38,18 @@ export async function initGeneralizationFunctions(tables) {
           RETURNS bytea AS $$
           DECLARE
             mvt bytea;
+            tolerance float;
           BEGIN
+            IF z BETWEEN 6 AND 14 THEN
+              tolerance = POWER(2, 14-z);
+            ELSE
+              tolerance = 0;
+            END IF;
             SELECT INTO mvt ST_AsMVT(tile, '${functionName}', 4096, 'geom') FROM (
               select
               *,
                 ST_AsMVTGeom(
-                    geom,
+                    ST_Simplify(geom, tolerance, true),
                     ST_TileEnvelope(z, x, y),
                     4096, 64, true) AS geom,
                   ${columnNames}

--- a/src/instrumentation/initGeneralizationFunctions.ts
+++ b/src/instrumentation/initGeneralizationFunctions.ts
@@ -11,7 +11,7 @@ export async function initGeneralizationFunctions(tables) {
 
       // Get column names and types
       const columnInformation = await prismaClientForRawQueries.$queryRawUnsafe(`
-        SELECT jsonb_object_agg(column_name, udt_name) - 'geom' AS fields
+        SELECT jsonb_object_agg(column_name, udt_name) - 'geom' - 'minzoom' AS fields
           FROM information_schema.columns
           WHERE table_schema = 'public' AND table_name = '${tableName}';`)
       const { fields } = columnInformation && columnInformation[0] // this object has the form {columnName: columnType}
@@ -75,57 +75,3 @@ export async function initGeneralizationFunctions(tables) {
     }),
   )
 }
-
-// original adapted
-
-// CREATE OR REPLACE
-//           FUNCTION public.${functionName}(z integer, x integer, y integer)
-//           RETURNS bytea AS $$
-//           BEGIN
-//           SELECT ST_AsMVT(tile, "${functionName}", 4096, 'geom')
-//           FROM (
-//             SELECT
-//               ST_AsMVTGeom(
-//                   ST_Transform(ST_CurveToLine("geom"), 3857),
-//                   ST_TileEnvelope(z, x, y),
-//                   4096, 64, true
-//               ) AS geom
-//               , "meta", "minzoom", "osm_id", "osm_type", "tags"
-//             FROM
-//               "public".${tableName}
-//             WHERE
-//               "geom" && ST_Transform(ST_TileEnvelope(z, x, y, margin => 0.015625), 3857)
-
-//           ) AS tile;
-//           END
-//           $$ LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE;
-
-// with simplify
-//  `CREATE OR REPLACE
-//  FUNCTION public.${functionName}(z integer, x integer, y integer)
-//  RETURNS bytea AS $$
-//  DECLARE
-//    mvt bytea;
-//    tolerance float;
-//  BEGIN
-//    IF z BETWEEN 6 AND 14 THEN
-//      tolerance = 0;
-//    ELSE
-//      tolerance = 0;
-//    END IF;
-//    SELECT INTO mvt ST_AsMVT(tile, '${functionName}', 4096, 'g') FROM (
-//      select
-//      *,
-//        ST_AsMVTGeom(
-//            ST_CurveToLine(
-//              ST_Simplify(geom, tolerance, true)
-//            ),
-//            ST_TileEnvelope(z, x, y),
-//            4096, 64, true) AS g
-//      FROM "${tableName}"
-//      WHERE (geom && ST_TileEnvelope(z, x, y))
-//        and  z >= minzoom
-//    ) AS tile WHERE geom IS NOT NULL;
-//    RETURN mvt;
-//  END
-//  $$ LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE;`,

--- a/src/instrumentation/initGeneralizationFunctions.ts
+++ b/src/instrumentation/initGeneralizationFunctions.ts
@@ -36,7 +36,7 @@ export async function initGeneralizationFunctions(
       // @ts-ignore
       const functionName = generalizationFunctionIdentifier(tableName)
       // Gather meta information for the tile specification
-      const tileSpecification = createTileSpecification(tableName)
+      const tileSpecification = await createTileSpecification(tableName)
       const { minzoom } = interactivity
       const stylingKeys = `Array[${interactivity.stylingKeys.map((tag) => `'${tag}'`)}]`
       return prismaClientForRawQueries.$transaction([

--- a/src/instrumentation/initGeneralizationFunctions.ts
+++ b/src/instrumentation/initGeneralizationFunctions.ts
@@ -18,7 +18,7 @@ export async function initGeneralizationFunctions(tables) {
       const columnNames = Object.keys(fields).join(', ')
       // Get the geometric extent
       const bbox = await prismaClientForRawQueries.$queryRawUnsafe(
-        `SELECT Array[ST_XMIN(bbox),ST_YMIN(bbox),ST_XMAX(bbox),ST_YMAX(bbox)] as bounds
+        `SELECT Array[ST_XMIN(bbox), ST_YMIN(bbox), ST_XMAX(bbox), ST_YMAX(bbox)] as bounds
           from (
             SELECT ST_Transform(ST_SetSRID(ST_Extent(geom), 3857), 4326) AS bbox
               from ${tableName}

--- a/src/instrumentation/initGeneralizationFunctions.ts
+++ b/src/instrumentation/initGeneralizationFunctions.ts
@@ -22,7 +22,7 @@ async function createTileSpecification(tableName) {
   const { bounds } = bbox && bbox[0]
   // format as vector tile specifaction
   const tileSpecification = {
-    vector_layers: [{ id: generalizationFunctionIdentifier(tableName), fields }],
+    vector_layers: [{ id: tableName, fields }],
     bounds,
   }
   return tileSpecification
@@ -60,7 +60,7 @@ export async function initGeneralizationFunctions(
             ELSE
               tolerance = 0;
             END IF;
-            SELECT INTO mvt ST_AsMVT(tile, '${functionName}', 4096, 'geom') FROM (
+            SELECT INTO mvt ST_AsMVT(tile, '${tableName}', 4096, 'geom') FROM (
               SELECT
                 ST_AsMVTGeom(
                     ST_CurveToLine(


### PR DESCRIPTION
This PR activates the first generalized layers for `bikelanes` and `roads`. The generalization reduces the data in three ways:
1. only data which has `minzoom` <= zoom gets displayed
2. the interactivity is only enabled for zoom >= `interactivity.minzoom`
3. the geometries get simplified between zoom 6-14