### PR TITLE
WIP: Highlighting of static dataset sources

### DIFF
--- a/src/app/regionen/[regionSlug]/_components/Map/Map.tsx
+++ b/src/app/regionen/[regionSlug]/_components/Map/Map.tsx
@@ -26,6 +26,7 @@ import { isSourceKeyAtlasGeo } from '../utils/sourceKeyUtils/sourceKeyUtilsAtlas
 import { Calculator } from './Calculator/Calculator'
 import { SourceGeojson } from './SourcesAndLayers/SourceGeojson/SourceGeojson'
 import { SourcesLayerRasterBackgrounds } from './SourcesAndLayers/SourcesLayerRasterBackgrounds'
+import { SourcesLayerStaticDatasetsHighlight } from './SourcesAndLayers/SourcesLayerStaticDatasetsHighlight'
 import { SourcesLayersAtlasGeo } from './SourcesAndLayers/SourcesLayersAtlasGeo'
 import { SourcesLayersOsmNotes } from './SourcesAndLayers/SourcesLayersOsmNotes'
 import { SourcesLayersRegionMask } from './SourcesAndLayers/SourcesLayersRegionMask'
@@ -93,7 +94,20 @@ export const Map = () => {
         // ctrl is not down - just set features
         newInspectorFeatures = uniqueFeatures
       }
+
+      interactiveFeatures?.forEach((feature) => {
+        mainMap?.setFeatureState(
+          { source: feature.source, sourceLayer: feature.sourceLayer, id: feature.id },
+          { selected: false },
+        )
+      })
       setInspectorFeatures(newInspectorFeatures)
+      newInspectorFeatures?.forEach((feature) => {
+        mainMap?.setFeatureState(
+          { source: feature.source, sourceLayer: feature.sourceLayer, id: feature.id },
+          { selected: true },
+        )
+      })
 
       const persistableFeatures = newInspectorFeatures.filter((f) => isSourceKeyAtlasGeo(f.source))
       if (persistableFeatures.length) {
@@ -196,6 +210,7 @@ export const Map = () => {
       <SourcesLayersRegionMask />
       <SourcesLayersAtlasGeo />
       <SourcesLayersStaticDatasets />
+      <SourcesLayerStaticDatasetsHighlight />
       <SourcesLayersOsmNotes />
       {isDev ? <SourceGeojson /> : null}
       <AttributionControl compact={true} position="bottom-left" />

--- a/src/app/regionen/[regionSlug]/_components/Map/SourcesAndLayers/SourcesLayerStaticDatasetsHighlight.tsx
+++ b/src/app/regionen/[regionSlug]/_components/Map/SourcesAndLayers/SourcesLayerStaticDatasetsHighlight.tsx
@@ -1,0 +1,88 @@
+import { featureCollection } from '@turf/turf'
+import { memo } from 'react'
+import { Layer, Source } from 'react-map-gl/maplibre'
+import {
+  StoreFeaturesInspector,
+  useMapStateInteraction,
+} from '../../../_hooks/mapStateInteraction/useMapStateInteraction'
+
+type Props = Pick<StoreFeaturesInspector, 'inspectorFeatures'>
+
+const SourcesLayerStaticDatasetsHighlightMemoized = memo(
+  function SourcesLayerStaticDatasetsHighlightMemoized({ inspectorFeatures }: Props) {
+    const groupedFeatures: Record<string, typeof inspectorFeatures> = {}
+    inspectorFeatures?.forEach((f) => {
+      const layerId = f.layer.id || 'boundary_country'
+      if (!groupedFeatures[layerId]) groupedFeatures[layerId] = []
+      groupedFeatures[layerId]!.push(f)
+    })
+
+    // TODO: Add … and abstract the condition into helper to reuse in <Inspector>
+    // const isDataset = regionDatasets.some(
+    //   (d) => d.id === extractSourceIdFromStaticDatasetSourceKey(sourceKey),
+    // )
+
+    return (
+      <>
+        {Object.entries(groupedFeatures).map(([groupKey, features]) => {
+          return (
+            <Source
+              key={groupKey}
+              id={`source--${groupKey}`}
+              type="geojson"
+              data={featureCollection(features || [])}
+            >
+              {/* <Layer
+                id={`highlights--line--${groupKey}`}
+                type="line"
+                beforeId={groupKey}
+                paint={{
+                  'line-color': 'black',
+                  'line-width': 10,
+                }}
+                filter={['==', '$type', 'LineString']}
+              />
+              <Layer
+                id={`highlights--circle--${groupKey}`}
+                type="circle"
+                beforeId={groupKey}
+                paint={{
+                  'circle-radius': 10,
+                  'circle-color': 'black',
+                  'circle-stroke-color': 'black',
+                  'circle-stroke-width': 2,
+                }}
+                filter={['==', '$type', 'Point']}
+              />
+              <Layer
+                id={`highlights--fill--${groupKey}`}
+                type="fill"
+                beforeId={groupKey}
+                paint={{
+                  'fill-color': 'black',
+                  'fill-opacity': 0.8,
+                }}
+                filter={['==', '$type', 'Polygon']}
+              />
+              <Layer
+                id={`highlights--fill-line--${groupKey}`}
+                type="line"
+                beforeId={groupKey || 'boundary_country'}
+                paint={{
+                  'line-color': 'black',
+                  'line-width': 10,
+                }}
+                filter={['==', '$type', 'Polygon']}
+              /> */}
+            </Source>
+          )
+        })}
+      </>
+    )
+  },
+)
+
+export const SourcesLayerStaticDatasetsHighlight = () => {
+  const { inspectorFeatures } = useMapStateInteraction()
+  return <SourcesLayerStaticDatasetsHighlightMemoized {...{ inspectorFeatures }} />
+}

--- a/src/app/regionen/[regionSlug]/_components/Map/SourcesAndLayers/SourcesLayersStaticDatasets.tsx
+++ b/src/app/regionen/[regionSlug]/_components/Map/SourcesAndLayers/SourcesLayersStaticDatasets.tsx
@@ -1,76 +1,88 @@
 import { Layer, LayerProps, Source } from 'react-map-gl/maplibre'
 import { useMapDebugState } from 'src/app/regionen/[regionSlug]/_hooks/mapStateInteraction/useMapDebugState'
 import { useDataParam } from 'src/app/regionen/[regionSlug]/_hooks/useQueryState/useDataParam'
+import { useMapStateInteraction } from '../../../_hooks/mapStateInteraction/useMapStateInteraction'
 import { useRegionDatasets } from '../../../_hooks/useRegionDatasets/useRegionDatasets'
 import { debugLayerStyles } from '../../../_mapData/mapDataSubcategories/mapboxStyles/debugLayerStyles'
 import {
-  createSourceKeyStaticDatasets,
   createDatasetSourceLayerKey,
+  createSourceKeyStaticDatasets,
 } from '../../utils/sourceKeyUtils/sourceKeyUtilsStaticDataset'
 import { layerVisibility } from '../utils/layerVisibility'
+import { extractHighlightFeatureIds } from './utils/extractHighlightFeatureIds'
 import { wrapFilterWithAll } from './utils/filterUtils/wrapFilterWithAll'
 import { pmtilesUrl } from './utils/pmtilesUrl'
 
-export const SourcesLayersStaticDatasets: React.FC = () => {
+export const SourcesLayersStaticDatasets = () => {
   const { dataParam: selectedDatasetIds } = useDataParam()
   const { useDebugLayerStyles } = useMapDebugState()
 
   const regionDatasets = useRegionDatasets()
+  const { inspectorFeatures } = useMapStateInteraction()
 
   if (!regionDatasets || !selectedDatasetIds) return null
 
   return (
     <>
-      {regionDatasets.map(({ id: sourceId, subId, type, url, attributionHtml, layers }) => {
-        const datasetSourceId = createSourceKeyStaticDatasets(sourceId, subId)
-        const visible = selectedDatasetIds.includes(datasetSourceId)
-        const visibility = layerVisibility(visible)
+      {regionDatasets.map(
+        ({ id: sourceId, subId, type, url, attributionHtml, layers, inspector }) => {
+          const datasetSourceId = createSourceKeyStaticDatasets(sourceId, subId)
+          const visible = selectedDatasetIds.includes(datasetSourceId)
+          const visibility = layerVisibility(visible)
 
-        return (
-          <Source
-            id={datasetSourceId}
-            key={datasetSourceId}
-            type={type}
-            url={pmtilesUrl(url)}
-            attribution={attributionHtml}
-          >
-            {layers.map((layer) => {
-              const layout =
-                layer.layout === undefined ? visibility : { ...visibility, ...layer.layout }
+          const highlightingKey =
+            'highlightingKey' in inspector && inspector?.highlightingKey !== 'TODO'
+              ? inspector?.highlightingKey
+              : undefined
+          const featureIds = highlightingKey
+            ? extractHighlightFeatureIds(inspectorFeatures, highlightingKey)
+            : []
 
-              const layerId = createDatasetSourceLayerKey(sourceId, subId, layer.id)
-              // Use ?debugMap=true and <DebugMap> to setUseDebugLayerStyles
-              const layerFilter = useDebugLayerStyles ? ['all'] : wrapFilterWithAll(layer.filter)
+          return (
+            <Source
+              id={datasetSourceId}
+              key={datasetSourceId}
+              type={type}
+              url={pmtilesUrl(url)}
+              attribution={attributionHtml}
+              promoteId={highlightingKey}
+            >
+              {layers.map((layer) => {
+                const layout =
+                  layer.layout === undefined ? visibility : { ...visibility, ...layer.layout }
 
-              // Use ?debugMap=true and <DebugMap> to setUseDebugLayerStyles
-              const layerPaint = useDebugLayerStyles
-                ? debugLayerStyles({
-                    source: sourceId,
-                    sourceLayer: 'default',
-                  }).find((l) => l.type === layer.type)?.paint
-                : (layer.paint as any)
+                const layerId = createDatasetSourceLayerKey(sourceId, subId, layer.id)
+                // Use ?debugMap=true and <DebugMap> to setUseDebugLayerStyles
+                const layerFilter = useDebugLayerStyles ? ['all'] : wrapFilterWithAll(layer.filter)
 
-              const layerProps = {
-                id: layerId,
-                source: datasetSourceId,
-                'source-layer': 'default', // set in `datasets/process.ts`
-                type: layer.type,
-                layout: layout,
-                filter: layerFilter,
-                paint: layerPaint,
-                beforeId:
-                  'beforeId' in layer
-                    ? layer.beforeId || 'atlas-app-beforeid-fallback'
-                    : 'atlas-app-beforeid-fallback',
-              }
+                // Use ?debugMap=true and <DebugMap> to setUseDebugLayerStyles
+                const layerPaint = useDebugLayerStyles
+                  ? debugLayerStyles({
+                      source: sourceId,
+                      sourceLayer: 'default',
+                    }).find((l) => l.type === layer.type)?.paint
+                  : (layer.paint as any)
 
-              // To get LayerHighlight working some more refactoring is needed to harmoize sourceData and datasetsData
-              // <LayerHighlight {...layerProps} />
-              return <Layer key={layerId} {...(layerProps as LayerProps)} />
-            })}
-          </Source>
-        )
-      })}
+                const layerProps = {
+                  id: layerId,
+                  source: datasetSourceId,
+                  'source-layer': 'default', // set in `datasets/process.ts`
+                  type: layer.type,
+                  layout: layout,
+                  filter: layerFilter,
+                  paint: layerPaint,
+                  beforeId:
+                    'beforeId' in layer
+                      ? layer.beforeId || 'atlas-app-beforeid-fallback'
+                      : 'atlas-app-beforeid-fallback',
+                }
+
+                return <Layer key={layerId} {...(layerProps as LayerProps)} />
+              })}
+            </Source>
+          )
+        },
+      )}
     </>
   )
 }


### PR DESCRIPTION
We can to this in three ways…

### Layer in existing source + `in` filter

This is what we do right now. However, I did not manage to get the filter working. No idea why that is so hard =(.
But we want to move away from this anyways, so …

My test cases are removed from this WIP commit.

### Geojson source

This is still in the code but inactive. It follows https://github.com/FixMyBerlin/atlas-app/pull/103.
We need to add a filter to only use datasets, see code todo.

### Use feature state

This might be the better option than Geojson source for datasets.
But then again we only want one pattern to do things, so https://github.com/FixMyBerlin/atlas-app/pull/103 will likely win?
Advantage
- speed
- styling is part of the static dataset repo, which is kind of nice and allows to specify the style

Issues
- we need to add unique IDs to the static datasets. There is a ticket on this with the idea to hash the feature. We can then remove the highlightKey config because we can check for this internal id in the properties.
- the handleClick needs to be cleaned up and split into helper functions
- feature state only works in `paint`, not in filter or layout.

Docs
- setfeaturestate https://maplibre.org/maplibre-gl-js/docs/API/classes/Map/#setfeaturestate
- example https://maplibre.org/maplibre-gl-js/docs/examples/hover-styles/
- expression https://maplibre.org/maplibre-style-spec/expressions/#feature-state