### PR TITLE
Add `id` to Export Endpoints

### DIFF
--- a/src/instrumentation/initExportFunctions.ts
+++ b/src/instrumentation/initExportFunctions.ts
@@ -32,6 +32,7 @@ export async function initExportFunctions(tables: typeof exportApiIdentifier) {
               jsonb_build_object('type', 'Feature', 'geometry',
               ST_AsGeoJSON(ST_Transform(geom, 4326))::jsonb,
               -- Reminder: All tables that can be exported are required to have those exact columns
+              'id', inputs.id,
               'properties', jsonb_build_object('osm_id', inputs.osm_id) ||
                   jsonb_build_object('osm_type', inputs.osm_type) || inputs.meta ||
                   inputs.tags) AS feature


### PR DESCRIPTION
Because we made the `id` a dedicated database column it was no longer available in the exports. This PR reintroduces but as the dedicated feature id weather as a property. The example bellow demonstrates this change.

Now:
```javascript
{
    type: 'feature',
    id: 'way/100',
    properties: {},
    geometry: ...
}
``` 
Before:
```javascript
{
    type: 'feature',
    properties: {
        id: 'way/100'
    },
    geometry: ...
}
``` 