### PR TITLE
Rework `prismaClientForRawQueries`

### DIFF
--- a/app/src/app/api/maproulette/[projectKey]/route.ts
+++ b/app/src/app/api/maproulette/[projectKey]/route.ts
@@ -31,7 +31,6 @@ export async function GET(request: NextRequest, { params }: { params: { projectK
   try {
     // PREPARE
     const { projectKey, ids } = parsedParams
-    await geoDataClient.$queryRaw`SET search_path TO public`
 
     // CHECK REGIONS (`ids` params)
     const nHits = await geoDataClient.$executeRaw`

--- a/app/src/app/api/maproulette/[projectKey]/route.ts
+++ b/app/src/app/api/maproulette/[projectKey]/route.ts
@@ -4,7 +4,7 @@ import { LineString } from '@turf/turf'
 import { NextRequest } from 'next/server'
 import { isProd } from 'src/app/_components/utils/isEnv'
 import { osmTypeIdString } from 'src/app/regionen/[regionSlug]/_components/SidebarInspector/Tools/osmUrls/osmUrls'
-import { prismaClientForRawQueries } from 'src/prisma-client'
+import { geoDataClient } from 'src/prisma-client'
 import { z } from 'zod'
 import { maprouletteProjects } from './_utils/maprouletteProjects.const'
 import { taskDescriptionMarkdown } from './_utils/taskMarkdown'
@@ -31,10 +31,10 @@ export async function GET(request: NextRequest, { params }: { params: { projectK
   try {
     // PREPARE
     const { projectKey, ids } = parsedParams
-    await prismaClientForRawQueries.$queryRaw`SET search_path TO public`
+    await geoDataClient.$queryRaw`SET search_path TO public`
 
     // CHECK REGIONS (`ids` params)
-    const nHits = await prismaClientForRawQueries.$executeRaw`
+    const nHits = await geoDataClient.$executeRaw`
       SELECT osm_id FROM boundaries WHERE osm_id IN (${Prisma.join(ids)})`
     if (nHits !== ids.length) {
       return new Response("Couldn't find given ids. At least one id is wrong or dupplicated.", {
@@ -55,7 +55,7 @@ export async function GET(request: NextRequest, { params }: { params: { projectK
     })()
 
     type QueryTpye = { type: string; id: string; category: string; geometry: LineString }[]
-    const sqlWays = await prismaClientForRawQueries.$queryRaw<QueryTpye>`
+    const sqlWays = await geoDataClient.$queryRaw<QueryTpye>`
       SELECT
         bikelanes.osm_type as type,
         bikelanes.osm_id as id,

--- a/app/src/app/api/maproulette/cycleway-shared/route.ts
+++ b/app/src/app/api/maproulette/cycleway-shared/route.ts
@@ -39,7 +39,6 @@ export async function GET(
   try {
     // PREPARE
     const { ids } = parsedParams
-    await geoDataClient.$queryRaw`SET search_path TO public`
 
     // CHECK REGIONS (`ids` params)
     const nHits = await geoDataClient.$executeRaw`

--- a/app/src/app/api/maproulette/cycleway-shared/route.ts
+++ b/app/src/app/api/maproulette/cycleway-shared/route.ts
@@ -8,7 +8,7 @@ import {
   osmTypeIdString,
 } from 'src/app/regionen/[regionSlug]/_components/SidebarInspector/Tools/osmUrls/osmUrls'
 import { pointFromGeometry } from 'src/app/regionen/[regionSlug]/_components/SidebarInspector/Tools/osmUrls/pointFromGeometry'
-import { prismaClientForRawQueries } from 'src/prisma-client'
+import { geoDataClient } from 'src/prisma-client'
 import { z } from 'zod'
 // import { maprouletteProjects } from './_utils/maprouletteProjects.const'
 // import { taskDescriptionMarkdown } from './_utils/taskMarkdown'
@@ -39,10 +39,10 @@ export async function GET(
   try {
     // PREPARE
     const { ids } = parsedParams
-    await prismaClientForRawQueries.$queryRaw`SET search_path TO public`
+    await geoDataClient.$queryRaw`SET search_path TO public`
 
     // CHECK REGIONS (`ids` params)
-    const nHits = await prismaClientForRawQueries.$executeRaw`
+    const nHits = await geoDataClient.$executeRaw`
       SELECT osm_id FROM boundaries WHERE osm_id IN (${Prisma.join(ids)})`
     if (nHits !== ids.length) {
       return new Response("Couldn't find given ids. At least one id is wrong or dupplicated.", {
@@ -51,7 +51,7 @@ export async function GET(
     }
 
     type QueryTpye = { type: string; id: string; geometry: LineString }[]
-    const sqlWays = await prismaClientForRawQueries.$queryRaw<QueryTpye>`
+    const sqlWays = await geoDataClient.$queryRaw<QueryTpye>`
       SELECT
         roads.osm_type as type,
         roads.osm_id as id,

--- a/app/src/app/api/maproulette/test/route.ts
+++ b/app/src/app/api/maproulette/test/route.ts
@@ -8,7 +8,7 @@ import {
   osmTypeIdString,
 } from 'src/app/regionen/[regionSlug]/_components/SidebarInspector/Tools/osmUrls/osmUrls'
 import { pointFromGeometry } from 'src/app/regionen/[regionSlug]/_components/SidebarInspector/Tools/osmUrls/pointFromGeometry'
-import { prismaClientForRawQueries } from 'src/prisma-client'
+import { geoDataClient } from 'src/prisma-client'
 import { z } from 'zod'
 // import { maprouletteProjects } from './_utils/maprouletteProjects.const'
 // import { taskDescriptionMarkdown } from './_utils/taskMarkdown'
@@ -37,10 +37,10 @@ export async function GET(
   try {
     // PREPARE
     const { ids } = parsedParams
-    await prismaClientForRawQueries.$queryRaw`SET search_path TO public`
+    await geoDataClient.$queryRaw`SET search_path TO public`
 
     // CHECK REGIONS (`ids` params)
-    const nHits = await prismaClientForRawQueries.$executeRaw`
+    const nHits = await geoDataClient.$executeRaw`
       SELECT osm_id FROM boundaries WHERE osm_id IN (${Prisma.join(ids)})`
     if (nHits !== ids.length) {
       return new Response("Couldn't find given ids. At least one id is wrong or dupplicated.", {
@@ -49,7 +49,7 @@ export async function GET(
     }
 
     type QueryTpye = { type: string; id: string; geometry: LineString }[]
-    const sqlWays = await prismaClientForRawQueries.$queryRaw<QueryTpye>`
+    const sqlWays = await geoDataClient.$queryRaw<QueryTpye>`
       SELECT
         roads.osm_type as type,
         roads.osm_id as id,

--- a/app/src/app/api/maproulette/test/route.ts
+++ b/app/src/app/api/maproulette/test/route.ts
@@ -37,7 +37,6 @@ export async function GET(
   try {
     // PREPARE
     const { ids } = parsedParams
-    await geoDataClient.$queryRaw`SET search_path TO public`
 
     // CHECK REGIONS (`ids` params)
     const nHits = await geoDataClient.$executeRaw`

--- a/app/src/app/api/maproulette/test2/route.ts
+++ b/app/src/app/api/maproulette/test2/route.ts
@@ -8,7 +8,7 @@ import {
   osmTypeIdString,
 } from 'src/app/regionen/[regionSlug]/_components/SidebarInspector/Tools/osmUrls/osmUrls'
 import { pointFromGeometry } from 'src/app/regionen/[regionSlug]/_components/SidebarInspector/Tools/osmUrls/pointFromGeometry'
-import { prismaClientForRawQueries } from 'src/prisma-client'
+import { geoDataClient } from 'src/prisma-client'
 import { z } from 'zod'
 // import { maprouletteProjects } from './_utils/maprouletteProjects.const'
 // import { taskDescriptionMarkdown } from './_utils/taskMarkdown'
@@ -37,10 +37,10 @@ export async function GET(
   try {
     // PREPARE
     const { ids } = parsedParams
-    await prismaClientForRawQueries.$queryRaw`SET search_path TO public`
+    await geoDataClient.$queryRaw`SET search_path TO public`
 
     // CHECK REGIONS (`ids` params)
-    const nHits = await prismaClientForRawQueries.$executeRaw`
+    const nHits = await geoDataClient.$executeRaw`
       SELECT osm_id FROM boundaries WHERE osm_id IN (${Prisma.join(ids)})`
     if (nHits !== ids.length) {
       return new Response("Couldn't find given ids. At least one id is wrong or dupplicated.", {
@@ -49,7 +49,7 @@ export async function GET(
     }
 
     type QueryTpye = { type: string; id: string; geometry: LineString }[]
-    const sqlWays = await prismaClientForRawQueries.$queryRaw<QueryTpye>`
+    const sqlWays = await geoDataClient.$queryRaw<QueryTpye>`
       SELECT
         roads.osm_type as type,
         roads.osm_id as id,

--- a/app/src/app/api/maproulette/test2/route.ts
+++ b/app/src/app/api/maproulette/test2/route.ts
@@ -37,7 +37,6 @@ export async function GET(
   try {
     // PREPARE
     const { ids } = parsedParams
-    await geoDataClient.$queryRaw`SET search_path TO public`
 
     // CHECK REGIONS (`ids` params)
     const nHits = await geoDataClient.$executeRaw`

--- a/app/src/app/regionen/[regionSlug]/stats/page.tsx
+++ b/app/src/app/regionen/[regionSlug]/stats/page.tsx
@@ -3,7 +3,7 @@ import { buttonStyles, linkStyles } from 'src/app/_components/links/styles'
 import { proseClasses } from 'src/app/_components/text/prose'
 import { ObjectDump } from 'src/app/admin/_components/ObjectDump'
 import { invoke } from 'src/blitz-server'
-import { prismaClientForRawQueries } from 'src/prisma-client'
+import { geoDataClient } from 'src/prisma-client'
 import getRegion from 'src/regions/queries/getRegion'
 import { twJoin } from 'tailwind-merge'
 import { hackyIdListForBB } from './list.const'
@@ -20,7 +20,7 @@ export async function generateMetadata({ params }) {
 
 export default async function ShowRegionStatsPage({ params, searchParams }) {
   const region = await invoke(getRegion, { slug: params.regionSlug })
-  const stats = await prismaClientForRawQueries.$queryRaw<any>`
+  const stats = await geoDataClient.$queryRaw<any>`
       SELECT osm_id::numeric, tags->'name', tags, meta, presence_categories
       FROM public."presenceStats"
       WHERE osm_id::text = ANY(${hackyIdListForBB.map(String)})`

--- a/app/src/instrumentation/initCustomFunctions.ts
+++ b/app/src/instrumentation/initCustomFunctions.ts
@@ -1,8 +1,8 @@
-import { prismaClientForRawQueries } from 'src/prisma-client'
+import { geoDataClient } from 'src/prisma-client'
 
 export async function initCustomFunctions() {
-  const queries = prismaClientForRawQueries.$transaction([
-    prismaClientForRawQueries.$executeRaw`
+  const queries = geoDataClient.$transaction([
+    geoDataClient.$executeRaw`
   CREATE OR REPLACE FUNCTION public.jsonb_select(json_in JSONB, keys text[])
   RETURNS JSONB AS $$
   DECLARE

--- a/app/src/instrumentation/initExportFunctions.ts
+++ b/app/src/instrumentation/initExportFunctions.ts
@@ -2,7 +2,7 @@ import {
   exportApiIdentifier,
   exportFunctionIdentifier,
 } from 'src/app/regionen/[regionSlug]/_mapData/mapDataSources/export/exportIdentifier'
-import { prismaClientForRawQueries } from 'src/prisma-client'
+import { geoDataClient } from 'src/prisma-client'
 
 // specify license and attribution for data export
 // const license = "'ODbL 1.0, https://opendatacommons.org/licenses/odbl/'"
@@ -12,22 +12,22 @@ export async function initExportFunctions(tables: typeof exportApiIdentifier) {
   return Promise.all(
     tables.map(async (tableName) => {
       const functionName = exportFunctionIdentifier(tableName)
-      const tagKeyQuery: Array<{ key: string }> = await prismaClientForRawQueries.$queryRawUnsafe(`
+      const tagKeyQuery: Array<{ key: string }> = await geoDataClient.$queryRawUnsafe(`
         SELECT DISTINCT jsonb_object_keys(tags) AS key
         FROM public."${tableName}"
       `)
-      const metaKeyQuery: Array<{ key: string }> = await prismaClientForRawQueries.$queryRawUnsafe(`
+      const metaKeyQuery: Array<{ key: string }> = await geoDataClient.$queryRawUnsafe(`
         SELECT DISTINCT jsonb_object_keys(meta) AS key
         FROM public."${tableName}"
       `)
       const tagKeys = tagKeyQuery.map(({ key }) => `tags->>'${key}' as "${key}"`).join(',')
       const metaKeys = metaKeyQuery.map(({ key }) => `meta->>'${key}' as "${key}"`).join(',')
 
-      return prismaClientForRawQueries.$transaction([
-        prismaClientForRawQueries.$executeRawUnsafe(
+      return geoDataClient.$transaction([
+        geoDataClient.$executeRawUnsafe(
           `DROP FUNCTION IF EXISTS public."${functionName}"(region Geometry(Polygon));`,
         ),
-        prismaClientForRawQueries.$executeRawUnsafe(
+        geoDataClient.$executeRawUnsafe(
           `CREATE FUNCTION public."${functionName}"(region Geometry(Polygon))
            RETURNS BYTEA
            LANGUAGE plpgsql

--- a/app/src/instrumentation/initExportFunctions.ts
+++ b/app/src/instrumentation/initExportFunctions.ts
@@ -24,7 +24,6 @@ export async function initExportFunctions(tables: typeof exportApiIdentifier) {
       const metaKeys = metaKeyQuery.map(({ key }) => `meta->>'${key}' as "${key}"`).join(',')
 
       return prismaClientForRawQueries.$transaction([
-        prismaClientForRawQueries.$executeRaw`SET search_path TO public;`,
         prismaClientForRawQueries.$executeRawUnsafe(
           `DROP FUNCTION IF EXISTS public."${functionName}"(region Geometry(Polygon));`,
         ),
@@ -38,12 +37,12 @@ export async function initExportFunctions(tables: typeof exportApiIdentifier) {
            BEGIN
             SELECT ST_AsFlatGeobuf(q, false, 'geom') INTO fgb FROM (
               SELECT st_transform(geom, 4326) AS geom,
-              id,
-              osm_id,
-              osm_type::text,
-              ${tagKeys},
-              ${metaKeys}
-              FROM public."${tableName}"
+                id,
+                osm_id,
+                osm_type::text,
+                ${tagKeys},
+                ${metaKeys}
+              FROM "${tableName}"
               WHERE geom && ST_Transform(region, 3857) AND minzoom > -1
             ) q;
             RETURN fgb;

--- a/app/src/instrumentation/initGeneralizationFunctions.ts
+++ b/app/src/instrumentation/initGeneralizationFunctions.ts
@@ -19,7 +19,6 @@ async function createTileSpecification(tableName: TableId) {
         FROM "${tableName}"
       ) extent;`,
   )
-  await geoDataClient.$executeRaw`SET search_path TO public;`
   const { bounds } = bbox && bbox[0]
   // format as vector tile specifaction
   const tileSpecification = {

--- a/app/src/pages/api/boundary.ts
+++ b/app/src/pages/api/boundary.ts
@@ -21,7 +21,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   try {
     const { ids } = params
-    await geoDataClient.$queryRawUnsafe('SET search_path TO public')
 
     const nHits = await geoDataClient.$executeRaw`
       SELECT osm_id

--- a/app/src/pages/api/boundary.ts
+++ b/app/src/pages/api/boundary.ts
@@ -1,7 +1,7 @@
 import { Prisma } from '@prisma/client'
 import { NextApiRequest, NextApiResponse } from 'next'
 import { isProd } from 'src/app/_components/utils/isEnv'
-import { prismaClientForRawQueries } from 'src/prisma-client'
+import { geoDataClient } from 'src/prisma-client'
 import { z } from 'zod'
 
 const idType = z.coerce.bigint().positive()
@@ -21,9 +21,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   try {
     const { ids } = params
-    await prismaClientForRawQueries.$queryRawUnsafe('SET search_path TO public')
+    await geoDataClient.$queryRawUnsafe('SET search_path TO public')
 
-    const nHits = await prismaClientForRawQueries.$executeRaw`
+    const nHits = await geoDataClient.$executeRaw`
       SELECT osm_id
       FROM boundaries
       WHERE osm_id IN (${Prisma.join(ids)})
@@ -33,7 +33,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return
     }
 
-    const boundary = await prismaClientForRawQueries.$queryRaw<Record<'geom', object>[]>`
+    const boundary = await geoDataClient.$queryRaw<Record<'geom', object>[]>`
       SELECT ST_AsGeoJSON(ST_Transform(ST_UNION(geom), 4326))::jsonb AS geom
       FROM boundaries
       WHERE osm_id IN (${Prisma.join(ids)})

--- a/app/src/pages/api/export/[regionSlug]/[tableName].ts
+++ b/app/src/pages/api/export/[regionSlug]/[tableName].ts
@@ -80,7 +80,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const { tableName, minlon, minlat, maxlon, maxlat } = params
     const functionName = exportFunctionIdentifier(tableName)
 
-    await geoDataClient.$executeRaw`SET search_path TO public;`
     const binaryResponse = await geoDataClient.$queryRawUnsafe<Buffer>(
       `SELECT * FROM "${functionName}"(
         ( SELECT * FROM ST_SetSRID(ST_MakeEnvelope(${minlon}, ${minlat}, ${maxlon}, ${maxlat}), 4326) )

--- a/app/src/pages/api/export/[regionSlug]/[tableName].ts
+++ b/app/src/pages/api/export/[regionSlug]/[tableName].ts
@@ -7,7 +7,7 @@ import {
   exportFunctionIdentifier,
 } from 'src/app/regionen/[regionSlug]/_mapData/mapDataSources/export/exportIdentifier'
 import { api } from 'src/blitz-server'
-import { prismaClientForRawQueries } from 'src/prisma-client'
+import { geoDataClient } from 'src/prisma-client'
 import { z } from 'zod'
 
 const ExportSchema = z.object({
@@ -80,8 +80,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const { tableName, minlon, minlat, maxlon, maxlat } = params
     const functionName = exportFunctionIdentifier(tableName)
 
-    await prismaClientForRawQueries.$executeRaw`SET search_path TO public;`
-    const binaryResponse = await prismaClientForRawQueries.$queryRawUnsafe<Buffer>(
+    await geoDataClient.$executeRaw`SET search_path TO public;`
+    const binaryResponse = await geoDataClient.$queryRawUnsafe<Buffer>(
       `SELECT * FROM "${functionName}"(
         ( SELECT * FROM ST_SetSRID(ST_MakeEnvelope(${minlon}, ${minlat}, ${maxlon}, ${maxlat}), 4326) )
       ) AS data`,

--- a/app/src/prisma-client.ts
+++ b/app/src/prisma-client.ts
@@ -4,5 +4,5 @@ import { PrismaClient } from '@prisma/client'
 // The idea is to use it with prismaClientForRawQueries.$queryRaw``
 // But only in situations where permissions are already handled by Blitz.
 export const geoDataClient = new PrismaClient({
-  datasourceUrl: (process.env.DATABASE_URL as string).replace('schema=prisma', 'schema=public'),
+  datasourceUrl: (process.env.DATABASE_URL as string).replace(/\?schema.*/, ''),
 })

--- a/app/src/prisma-client.ts
+++ b/app/src/prisma-client.ts
@@ -3,4 +3,6 @@ import { PrismaClient } from '@prisma/client'
 // This is experimental. It is used in /regionen/slug/stats (page RSC).
 // The idea is to use it with prismaClientForRawQueries.$queryRaw``
 // But only in situations where permissions are already handled by Blitz.
-export const prismaClientForRawQueries = new PrismaClient()
+export const prismaClientForRawQueries = new PrismaClient({
+  datasourceUrl: (process.env.DATABASE_URL as string).replace('schema=prisma', 'schema=public'),
+})

--- a/app/src/prisma-client.ts
+++ b/app/src/prisma-client.ts
@@ -3,6 +3,6 @@ import { PrismaClient } from '@prisma/client'
 // This is experimental. It is used in /regionen/slug/stats (page RSC).
 // The idea is to use it with prismaClientForRawQueries.$queryRaw``
 // But only in situations where permissions are already handled by Blitz.
-export const prismaClientForRawQueries = new PrismaClient({
+export const geoDataClient = new PrismaClient({
   datasourceUrl: (process.env.DATABASE_URL as string).replace('schema=prisma', 'schema=public'),
 })

--- a/app/src/prisma-client.ts
+++ b/app/src/prisma-client.ts
@@ -1,8 +1,7 @@
 import { PrismaClient } from '@prisma/client'
 
-// This is experimental. It is used in /regionen/slug/stats (page RSC).
-// The idea is to use it with prismaClientForRawQueries.$queryRaw``
-// But only in situations where permissions are already handled by Blitz.
+// This is the client for accessing the geo data.
+// It allows direct SQL queries to the database, so it should be used cautiously as it bypasses Prisma's integrated security checks.
 export const geoDataClient = new PrismaClient({
   datasourceUrl: (process.env.DATABASE_URL as string).replace(/\?schema.*/, ''),
 })


### PR DESCRIPTION
This PR reworks the`prismaClientForRawQueries` renaming it as `geoDataClient`. It removes the `schema=prisma` restriction which simplifies a lot of our quries because we don't need to change the `search_path` everytime.
Also solves [#1936](https://github.com/FixMyBerlin/private-issues/issues/1936).