### PR TITLE
Move `implicitOneWay` Information to the `bikelanCategory` class

### DIFF
--- a/processing/topics/roads_bikelanes/bikelanes/BikelaneCategories.lua
+++ b/processing/topics/roads_bikelanes/bikelanes/BikelaneCategories.lua
@@ -16,6 +16,7 @@ function BikelaneCategory.new(args)
   self.id = args.id
   self.desc = args.desc
   self.infrastructureExists = args.infrastructureExists
+  self.implicitOneWay = args.implicitOneWay
   self.condition = args.condition
   return self
 end
@@ -143,6 +144,7 @@ local footAndCyclewayShared = BikelaneCategory.new({
   id = 'footAndCyclewayShared',
   desc = 'Shared bike and foot path (DE: "Gemeinsamer Geh- und Radweg")',
   infrastructureExists = true,
+  implicitOneWay = true,
   condition = function(tags)
     local trafficSign = SanitizeTrafficSign(tags.traffic_sign)
     local taggedWithAccessTagging = tags.bicycle == "designated" and tags.foot == "designated" and
@@ -163,6 +165,7 @@ local footAndCyclewaySegregated = BikelaneCategory.new({
   id = 'footAndCyclewaySegregated',
   desc = 'Shared bike and foot path (DE: "Getrennter Geh- und Radweg", "Getrennter Rad- und Gehweg")',
   infrastructureExists = true,
+  implicitOneWay = true,
   condition = function(tags)
     local trafficSign = SanitizeTrafficSign(tags.traffic_sign)
     local taggedWithAccessTagging = tags.bicycle == "designated" and tags.foot == "designated" and
@@ -182,6 +185,7 @@ local footwayBicycleYes = BikelaneCategory.new({
   desc = 'Footway / Sidewalk with explicit allowance for bicycles (`bicycle=yes`)' ..
       ' (DE: "Gehweg, Fahrrad frei")',
   infrastructureExists = true,
+  implicitOneWay = true,
   condition = function(tags)
     local trafficSign = SanitizeTrafficSign(tags.traffic_sign)
 
@@ -285,6 +289,7 @@ local cyclewayOnHighway_advisory = BikelaneCategory.new({
   desc = 'Bicycle infrastructure on the highway, right next to motor vehicle traffic.' ..
       'For "advisory" lanes (DE: "Schutzstreifen")',
   infrastructureExists = true,
+  implicitOneWay = true,
   condition = function(tags)
     if tags.highway == 'cycleway' then
       if tags.cycleway == "lane" or tags.cycleway == "opposite_lane" then
@@ -304,6 +309,7 @@ local cyclewayOnHighway_exclusive = BikelaneCategory.new({
   desc = 'Bicycle infrastrucute on the highway, right next to motor vehicle traffic.' ..
       ' For "exclusive" lanes (DE: "Radfahrstreifen").',
   infrastructureExists = true,
+  implicitOneWay = true,
   condition = function(tags)
     if tags.highway == 'cycleway' then
       if tags.cycleway == "lane" or tags.cycleway == "opposite_lane" then
@@ -324,6 +330,7 @@ local cyclewayOnHighway_advisoryOrExclusive = BikelaneCategory.new({
       ' This category is split into subcategories for "advisory" (DE: "Schutzstreifen")' ..
       ' and "exclusive" lanes (DE: "Radfahrstreifen").',
   infrastructureExists = true,
+  implicitOneWay = true,
   condition = function(tags)
     if tags.highway == 'cycleway' then
       if tags.cycleway == "lane" or tags.cycleway == "opposite_lane" then
@@ -354,6 +361,7 @@ local cyclewayOnHighwayBetweenLanes = BikelaneCategory.new({
   desc = 'Bike lane between motor vehicle lanes,' ..
       ' mostly on the left of a right turn lane. (DE: "Radweg in Mittellage")',
   infrastructureExists = true,
+  implicitOneWay = true,
   condition = function(tags)
     if tags['_parent_highway'] == nil or tags._prefix == 'sidewalk' then return end
 
@@ -377,6 +385,7 @@ local sharedBusLaneBusWithBike = BikelaneCategory.new({
   desc = 'Bus lane with explicit allowance for bicycles (`cycleway=share_busway`).' ..
       ' (DE: "Bussonderfahrstreifen mit Fahrrad frei")',
   infrastructureExists = true,
+  implicitOneWay = true,
   condition = function(tags)
     local trafficSign = SanitizeTrafficSign(tags.traffic_sign)
     local taggedWithAccessTagging = tags.highway == "cycleway" and
@@ -402,6 +411,7 @@ local sharedBusLaneBikeWithBus = BikelaneCategory.new({
   desc = 'Bicycle lane with explicit allowance for buses.' ..
       ' (DE: "Radfahrstreifen mit Freigabe Busverkehr")',
   infrastructureExists = true,
+  implicitOneWay = true,
   condition = function(tags)
     local trafficSign = SanitizeTrafficSign(tags.traffic_sign)
     local taggedWithAccessTagging = tags.highway == "cycleway" and tags.lane == "share_busway"
@@ -454,6 +464,7 @@ local protectedCyclewayOnHighway = BikelaneCategory.new({
   id = 'protectedCyclewayOnHighway',
   desc = 'Protected bikelanes e.g. bikelanes with physical separation from motorized traffic.',
   infrastructureExists = true,
+  implicitOneWay = true,
   condition = function(tags)
     local nonPhysicalSeparations = Set({'no', 'none', 'dashed_line', 'solid_line'})
     -- we go from specific to general tags (:side > :both > '')

--- a/processing/topics/roads_bikelanes/bikelanes/Bikelanes.lua
+++ b/processing/topics/roads_bikelanes/bikelanes/Bikelanes.lua
@@ -69,7 +69,7 @@ function Bikelanes(object)
           _age = AgeInDays(ParseCheckDate(tags["check_date"])),
           prefix = transformedTags._prefix,
           width = ParseLength(transformedTags.width),
-          oneway = DeriveOneway(transformedTags, category.id),
+          oneway = DeriveOneway(transformedTags, category),
           bridge = Sanitize(tags.bridge, { "yes" }),
           tunnel = Sanitize(tags.tunnel, { "yes" }),
         })

--- a/processing/topics/roads_bikelanes/bikelanes/DeriveOneway.lua
+++ b/processing/topics/roads_bikelanes/bikelanes/DeriveOneway.lua
@@ -2,41 +2,7 @@ package.path = package.path .. ";/processing/topics/helper/?.lua"
 require("Set")
 require("Sanitize")
 
--- Our data should be explicit about tagging that OSM considers default/implicit as well assumed defaults.
-local onewayAssumedNo = Set({
-  'bicycleRoad',                        -- road shared, both lanes
-  'bicycleRoad_vehicleDestination',     -- road shared, both lanes
-  'livingStreet',                       -- road shared, both lanes
-  'pedestrianAreaBicycleYes',           -- road shared, both lanes
-  'sharedMotorVehicleLane',             -- (both) road shared, both lanes, (left|right would be `implicit_yes`)
-  'explicitSharedLaneButNoSignage',     -- (both) road shared, both lanes, (left|right would be `implicit_yes`)
-  'footAndCyclewayShared_isolated',     -- "track"-like
-  'footAndCyclewaySegregated_isolated', -- "track"-like
-  'cycleway_adjoining',                 -- "track"-like and `oneway=yes` (common in cities) is usually explicit
-  'cycleway_isolated',                  -- road for bikes `oneway=yes` unexpected or usually explicit
-  'cycleway_adjoiningOrIsolated',       -- "track"-like
-  'crossing',                           -- really unknown, but `oneway=yes` (which is common in cities) is usually explicit
-  'cyclewayLink',                       -- really unknown, but `oneway=yes` (which is common in cities) is usually explicit
-  'needsClarification'                  -- really unknown, but `oneway=yes` (which is common in cities) is usually explicit
-})
-local onewayImplicitYes = Set({
-  'protectedCyclewayOnHighway',                    -- "lane"-like
-  'cyclewayOnHighway_advisory',                    -- "lane"-like
-  'cyclewayOnHighway_exclusive',                   -- "lane"-like
-  'cyclewayOnHighway_advisoryOrExclusive',         -- "lane"-like
-  'cyclewayOnHighwayBetweenLanes',                 -- "lane"-like
-  'sharedBusLaneBikeWithBus',                      -- "shared lane"-like
-  'sharedBusLaneBusWithBike',                      -- "shared lane"-like
-  'footAndCyclewayShared_adjoining',               -- "shared lane"-like
-  'footAndCyclewayShared_adjoiningOrIsolated',     -- unclear, fall back to "shared lane"-like
-  'footAndCyclewaySegregated_adjoining',           -- "lane"-like
-  'footAndCyclewaySegregated_adjoiningOrIsolated', -- unclear, fall back to "lane"-like
-  'footwayBicycleYes_adjoining',                   -- "shared lane"-like
-  'footwayBicycleYes_isolated',                    -- "shared lane"-like, still assuming "oneway=yes" because too little space or it would be "footAndCyclewayShared_isolated"
-  'footwayBicycleYes_adjoiningOrIsolated'          -- unclear, fall back to "shared lane"-like
-})
-
----@param category string
+---@param category table
 ---@return 'yes' | 'no' | 'car_not_bike' | 'assumed_no' | 'implicit_yes' | 'unknown'
 --- Derive oneway information based on tags and given category
 function DeriveOneway(tags, category)
@@ -55,14 +21,9 @@ function DeriveOneway(tags, category)
     return tags.oneway
   end
 
-  if onewayAssumedNo[category] then
-    return 'assumed_no'
-  end
-
-  if onewayImplicitYes[category] then
+  if category.implicitOneWay then
     return 'implicit_yes'
   end
 
-  -- This should never happen / maybe in some kind of TODO-list
-  return 'unknown'
+  return 'assumed_no'
 end

--- a/processing/topics/roads_bikelanes/bikelanes/categories/CreateSubcategoriesAdjoiningOrIsolated.lua
+++ b/processing/topics/roads_bikelanes/bikelanes/categories/CreateSubcategoriesAdjoiningOrIsolated.lua
@@ -5,18 +5,21 @@ function CreateSubcategoriesAdjoiningOrIsolated(category)
     id = category.id .. '_adjoining',
     desc = category.desc .. ' (adjoining)',
     infrastructureExists = category.infrastructureExists,
+    implicitOneWay = category.implicitOneWay,
     condition = function(tags) return category(tags) and IsSidepath(tags) and tags.is_sidepath ~= "no" end
   })
   local isolated = BikelaneCategory.new({
     id = category.id .. '_isolated',
     desc = category.desc .. ' (isolated)',
     infrastructureExists = category.infrastructureExists,
+    implicitOneWay = category.implicitOneWay,
     condition = function(tags) return category(tags) and tags.is_sidepath == "no" end
   })
   local adjoiningOrIsolated = BikelaneCategory.new({
     id = category.id .. '_adjoiningOrIsolated',
     desc = category.desc .. ' (adjoiningOrIsolated)',
     infrastructureExists = category.infrastructureExists,
+    implicitOneWay = category.implicitOneWay,
     condition = function(tags) return category(tags) and not IsSidepath(tags) and tags.is_sidepath ~= "no" end
   })
   return adjoining, isolated, adjoiningOrIsolated


### PR DESCRIPTION
After I added two new `bikelaneCategories` and forgot to update the `assumedNo` and `implicitYes` lists I realized it would be better to keep that information attached to the category itself.  @tordans we had that idea before but never refactored it.