### PR TITLE
Sidebar: Add resize functionality

### DIFF
--- a/app/src/app/regionen/[regionSlug]/_components/SidebarInspector/ResizeHandle.tsx
+++ b/app/src/app/regionen/[regionSlug]/_components/SidebarInspector/ResizeHandle.tsx
@@ -1,0 +1,27 @@
+import { forwardRef } from 'react'
+
+type Props = {
+  onResizeStart: (e: React.MouseEvent) => void
+  inspectorWidth: number
+}
+
+export const ResizeHandle = forwardRef<HTMLDivElement, Props>(
+  ({ onResizeStart, inspectorWidth }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className="fixed top-0 bottom-0 z-30 w-1 cursor-col-resize hover:bg-purple-500 transition-colors duration-150"
+        style={{ right: `${inspectorWidth - 1}px` }}
+        onMouseDown={onResizeStart}
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Größe der Sidebar ändern"
+      >
+        {/* Größerer Hit-Area zum einfacheren Greifen */}
+        <div className="absolute left-0 top-0 bottom-0 w-3 -translate-x-1" />
+      </div>
+    )
+  },
+)
+
+ResizeHandle.displayName = 'ResizeHandle'

--- a/app/src/app/regionen/[regionSlug]/_components/SidebarInspector/SidebarInspector.tsx
+++ b/app/src/app/regionen/[regionSlug]/_components/SidebarInspector/SidebarInspector.tsx
@@ -1,10 +1,11 @@
 import { Spinner } from '@/src/app/_components/Spinner/Spinner'
 import { useSelectedFeatures } from '@/src/app/regionen/[regionSlug]/_hooks/useQueryState/useFeaturesParam/useSelectedFeatures'
-import { Suspense, useRef } from 'react'
+import { Suspense, useCallback, useEffect, useRef, useState } from 'react'
 import { useMap } from 'react-map-gl/maplibre'
 import { twJoin } from 'tailwind-merge'
 import useResizeObserver from 'use-resize-observer'
 import {
+  useInspectorWidthStore,
   useMapActions,
   useMapBounds,
   useMapInspectorFeatures,
@@ -15,6 +16,7 @@ import {
 import { useFeaturesParam } from '../../_hooks/useQueryState/useFeaturesParam/useFeaturesParam'
 import { Inspector } from './Inspector'
 import { InspectorHeader } from './InspectorHeader'
+import { ResizeHandle } from './ResizeHandle'
 import { allUrlFeaturesInBounds, createBoundingPolygon, fitBounds } from './util'
 
 export const SidebarInspector = () => {
@@ -30,14 +32,90 @@ export const SidebarInspector = () => {
 
   const { resetInspectorFeatures, setInspectorSize } = useMapActions()
 
-  const { ref } = useResizeObserver<HTMLDivElement>({
+  // Resize functionality
+  const inspectorWidth = useInspectorWidthStore((state) => state.inspectorWidth)
+  const setInspectorWidth = useInspectorWidthStore((state) => state.setInspectorWidth)
+  const [isResizing, setIsResizing] = useState(false)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const resizeHandleRef = useRef<HTMLDivElement | null>(null)
+  const styleElementRef = useRef<HTMLStyleElement | null>(null)
+  const startXRef = useRef(0)
+  const startWidthRef = useRef(0)
+  const lastWidthRef = useRef(0)
+
+  const updateWidth = useCallback((width: number) => {
+    lastWidthRef.current = width
+    if (containerRef.current) {
+      containerRef.current.style.width = `${width}px`
+    }
+    if (resizeHandleRef.current) {
+      resizeHandleRef.current.style.right = `${width - 1}px`
+    }
+    if (styleElementRef.current) {
+      styleElementRef.current.textContent = `.maplibregl-ctrl-top-right { right: ${width}px } [data-map-controls="true"] { right: calc(${width}px + 10px) }`
+    }
+  }, [])
+
+  const handleResizeStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault()
+      setIsResizing(true)
+      startXRef.current = e.clientX
+      startWidthRef.current = inspectorWidth
+    },
+    [inspectorWidth],
+  )
+
+  useEffect(() => {
+    if (!isResizing) return
+
+    const handleMouseMove = (e: MouseEvent) => {
+      const delta = startXRef.current - e.clientX
+      const newWidth = startWidthRef.current + delta
+      // Min: 320px (20rem), Max: 800px (50rem)
+      const clampedWidth = Math.min(Math.max(newWidth, 320), 800)
+      updateWidth(clampedWidth)
+    }
+
+    const handleMouseUp = () => {
+      const finalWidth = lastWidthRef.current
+      // Save to persistent store only once
+      setInspectorWidth(finalWidth)
+      setIsResizing(false)
+
+      // Update inspectorSize in store after resize is complete
+      if (containerRef.current) {
+        const height = containerRef.current.offsetHeight
+        setInspectorSize({ width: finalWidth, height })
+      }
+    }
+
+    document.addEventListener('mousemove', handleMouseMove, { passive: true })
+    document.addEventListener('mouseup', handleMouseUp)
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove)
+      document.removeEventListener('mouseup', handleMouseUp)
+    }
+  }, [isResizing, setInspectorWidth, updateWidth])
+
+  const { ref: observerRef } = useResizeObserver<HTMLDivElement>({
     box: 'border-box',
     onResize: ({ width, height }) => {
+      // Don't update store during manual resize to prevent re-renders
+      if (isResizing) return
       if (width !== undefined && height !== undefined) {
         setInspectorSize({ width, height })
       }
     },
   })
+
+  const ref = useCallback(
+    (node: HTMLDivElement | null) => {
+      containerRef.current = node
+      observerRef(node)
+    },
+    [observerRef],
+  )
 
   if (inspectorFeatures.length) {
     // TODO: See https://github.com/FixMyBerlin/private-issues/issues/1775
@@ -70,28 +148,40 @@ export const SidebarInspector = () => {
   const renderFeatures = !!features.length
 
   const { setFeaturesParam } = useFeaturesParam()
-  const handleClose = () => {
+  const handleClose = useCallback(() => {
     setFeaturesParam(null)
     resetInspectorFeatures()
-  }
+  }, [setFeaturesParam, resetInspectorFeatures])
 
   return (
     <div
       ref={ref}
+      style={{ width: `${inspectorWidth}px` }}
       className={twJoin(
-        'absolute top-0 right-0 bottom-0 z-20 w-[35rem] max-w-full overflow-y-scroll bg-white p-5 pr-3 shadow-md',
+        'absolute top-0 right-0 bottom-0 z-20 max-w-full overflow-y-scroll bg-white p-5 pr-3 shadow-md',
         !renderFeatures && 'pointer-events-none opacity-0',
       )}
     >
+      {isResizing && (
+        <div
+          className="fixed inset-0 z-50 cursor-col-resize"
+          style={{ background: 'rgba(147, 51, 234, 0.05)' }}
+        />
+      )}
       <Suspense fallback={<Spinner />}>
         {renderFeatures ? (
           <>
+            <ResizeHandle
+              ref={resizeHandleRef}
+              onResizeStart={handleResizeStart}
+              inspectorWidth={inspectorWidth}
+            />
             <InspectorHeader count={features.length} handleClose={handleClose} />
             <Inspector features={features} />
             <style
+              ref={styleElementRef}
               dangerouslySetInnerHTML={{
-                __html:
-                  '.maplibregl-ctrl-top-right { right: 35rem } [data-map-controls="true"] { right: calc(35rem + 10px) }',
+                __html: `.maplibregl-ctrl-top-right { right: ${inspectorWidth}px } [data-map-controls="true"] { right: calc(${inspectorWidth}px + 10px) }`,
               }}
             />
           </>

--- a/app/src/app/regionen/[regionSlug]/_hooks/mapState/useMapState.ts
+++ b/app/src/app/regionen/[regionSlug]/_hooks/mapState/useMapState.ts
@@ -2,6 +2,7 @@ import { isEqual } from 'lodash'
 import { LngLatBounds } from 'maplibre-gl'
 import { MapGeoJSONFeature } from 'react-map-gl/maplibre'
 import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
 
 // INFO DEBUGGING: We could use a middleware to log state changes https://github.com/pmndrs/zustand#middleware
 export type Store = StoreMapLoadedState &
@@ -110,3 +111,21 @@ export const useMapInspectorSize = () => useMapState((state) => state.inspectorS
 export const useMapSidebarSize = () => useMapState((state) => state.sidebarSize)
 
 export const useMapActions = () => useMapState((state) => state.actions)
+
+// Persistent store for inspector width
+type InspectorWidthStore = {
+  inspectorWidth: number
+  setInspectorWidth: (width: number) => void
+}
+
+export const useInspectorWidthStore = create<InspectorWidthStore>()(
+  persist(
+    (set) => ({
+      inspectorWidth: 560, // 35rem default
+      setInspectorWidth: (width) => set({ inspectorWidth: width }),
+    }),
+    {
+      name: 'tilda-inspector-width',
+    },
+  ),
+)


### PR DESCRIPTION
This PR enables the sidebar to be resizable via a purple line at the edge.

Notable changes:
- Inspector size will be saved in localStorage via zustand for consistent views at tabs and reloads
- Mobile view is not affected

Side effects:
- This makes the Mapillary window notably bigger