### PR TITLE
chore(deps): ignore eslint-plugin-react-compiler in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,7 @@ updates:
           - version-update:semver-major
           - version-update:semver-minor
           - version-update:semver-patch
+      - dependency-name: eslint-plugin-react-compiler
     groups:
       security-dev-tools:
         applies-to: security-updates


### PR DESCRIPTION
## Summary
- Add a Dependabot ignore for `eslint-plugin-react-compiler` after #322 proposed a downgrade (beta `20250411` → `20250131`).
- The package stays pinned manually in `app/package.json` until a newer beta is published.

## Test plan
- [x] Pre-commit passed locally
- [ ] CI green on PR

Made with [Cursor](https://cursor.com)