### PR TITLE
Processing: retry Bun connect failures and keep warm-cache alive

### DIFF
--- a/app/src/routes/api/private/warm-cache.ts
+++ b/app/src/routes/api/private/warm-cache.ts
@@ -6,6 +6,7 @@ import type { StaticRegion } from '@/data/regions.const'
 import { staticRegion } from '@/data/regions.const'
 import { guardEndpoint } from '@/server/api/private/guardEndpoint'
 import { warmCache } from '@/server/api/private/warmCache'
+import { extendBunRequestIdleTimeout } from '@/server/http/extendBunRequestIdleTimeout.server'
 
 const Schema = z.object({
   apiKey: z.string(),
@@ -31,6 +32,10 @@ export const Route = createFileRoute('/api/private/warm-cache')({
   server: {
     handlers: {
       GET: async ({ request }) => {
+        // Full warming can take minutes with zero response bytes until complete.
+        // Bun's default ~10s idleTimeout otherwise closes the connection (empty reply).
+        extendBunRequestIdleTimeout(request, 0)
+
         const { access, response } = guardEndpoint(request, Schema)
         if (access === false) return response
 

--- a/processing/scripts/run-tests.ts
+++ b/processing/scripts/run-tests.ts
@@ -1,13 +1,12 @@
 #!/usr/bin/env bun
+import { resolve } from 'node:path'
 import { $ } from 'bun'
 
 process.env.PATH = `/usr/local/bin:/opt/homebrew/bin:${process.env.HOME}/.docker/bin:${process.env.PATH ?? ''}`
 
-const root = (await $`git rev-parse --show-toplevel`.quiet()).text().trim()
-if (!root) {
-  console.error('Not inside a git repository.')
-  process.exit(1)
-}
+// Path-based root: during `git push`, husky sets GIT_DIR and `git rev-parse --show-toplevel`
+// from processing/ resolves to this package dir instead of the worktree/repo root.
+const root = resolve(import.meta.dir, '../..')
 
 const dockerCheck = await $`command -v docker`.quiet().nothrow()
 if (dockerCheck.exitCode !== 0) {

--- a/processing/scripts/run-typecheck-lua.ts
+++ b/processing/scripts/run-typecheck-lua.ts
@@ -1,13 +1,12 @@
 #!/usr/bin/env bun
+import { resolve } from 'node:path'
 import { $ } from 'bun'
 
 process.env.PATH = `/usr/local/bin:/opt/homebrew/bin:${process.env.HOME}/.docker/bin:${process.env.PATH ?? ''}`
 
-const root = (await $`git rev-parse --show-toplevel`.quiet()).text().trim()
-if (!root) {
-  console.error('Not inside a git repository.')
-  process.exit(1)
-}
+// Path-based root: during `git push`, husky sets GIT_DIR and `git rev-parse --show-toplevel`
+// from processing/ resolves to this package dir instead of the worktree/repo root.
+const root = resolve(import.meta.dir, '../..')
 
 const dockerCheck = await $`command -v docker`.quiet().nothrow()
 if (dockerCheck.exitCode !== 0) {

--- a/processing/steps/externalTriggers.ts
+++ b/processing/steps/externalTriggers.ts
@@ -1,6 +1,23 @@
 import { isDev } from '../utils/isDev'
 import { params } from '../utils/parameters'
 
+/** Bun/Node connection failures that should retry while the app container restarts. */
+function isRetryableConnectionError(error: unknown) {
+  if (!(error instanceof Error)) return false
+
+  const message = error.message.toLowerCase()
+  return (
+    message.includes('econnreset') ||
+    message.includes('econnrefused') ||
+    message.includes('socket') ||
+    message.includes('connection') ||
+    // Bun: "Unable to connect. Is the computer able to access the url?"
+    message.includes('unable to connect') ||
+    // Bun: "Was there a typo in the url or port?"
+    message.includes('typo in the url')
+  )
+}
+
 export async function triggerPrivateApi(endpoint: string, retryCount = 0) {
   const domain = isDev ? 'http://127.0.0.1:5173' : 'http://app:4000'
   const privateApiUrl = `${domain}/api/private/${endpoint}`
@@ -28,7 +45,7 @@ export async function triggerPrivateApi(endpoint: string, retryCount = 0) {
     clearTimeout(timeoutId)
     if (!response.ok) {
       console.warn(
-        `[ERROR] Finishing up: ⚠️ Calling the ${endpoint} hook failed. This is likely due to the NextJS application not running.`,
+        `[ERROR] Finishing up: ⚠️ Calling the ${endpoint} hook failed. This is likely due to the app container not running.`,
         response.status,
       )
     } else {
@@ -41,15 +58,11 @@ export async function triggerPrivateApi(endpoint: string, retryCount = 0) {
   } catch (error) {
     clearTimeout(timeoutId)
 
-    // Retry on connection errors (likely app container restarting)
-    const isConnectionError =
-      error instanceof Error &&
-      (error.name === 'AbortError' ||
-        error.message.includes('ECONNRESET') ||
-        error.message.includes('socket') ||
-        error.message.includes('connection'))
+    // Our AbortController timeout is not a transient connection blip — do not retry it.
+    const timedOutByUs =
+      error instanceof Error && error.name === 'AbortError' && controller.signal.aborted
 
-    if (isConnectionError && retryCount < maxRetries) {
+    if (!timedOutByUs && isRetryableConnectionError(error) && retryCount < maxRetries) {
       console.warn(
         `[ERROR] Finishing up: ⚠️ Failed to trigger ${endpoint} (attempt ${retryCount + 1}/${maxRetries + 1}). Retrying in ${retryDelayMs / 1000} seconds...`,
         error instanceof Error ? error.message : String(error),
@@ -59,14 +72,14 @@ export async function triggerPrivateApi(endpoint: string, retryCount = 0) {
     }
 
     // Log the error but don't crash the processing pipeline (no throw)
-    if (error instanceof Error && error.name === 'AbortError') {
+    if (timedOutByUs) {
       console.warn(
         `[ERROR] Finishing up: ⚠️ Request to ${endpoint} timed out after ${timeoutMs / 1000 / 60} minutes`,
       )
     } else {
       console.warn(
         `[ERROR] Finishing up: ⚠️ Failed to trigger ${endpoint} after ${retryCount + 1} attempts. Operation was not triggered and will not run.`,
-        'Try callig it manually:',
+        'Try calling it manually:',
         redactedCurlCommand,
         error instanceof Error ? error.message : String(error),
       )


### PR DESCRIPTION
## Summary
- Processing post-processing hooks retry on Bun connection errors (`Unable to connect`, typo/url messages) so deploys where `app` comes up a few minutes after processing no longer skip QA/hook/warm-cache after one attempt
- `warm-cache` disables Bun’s ~10s idle timeout so long warming jobs do not get empty replies mid-run
- Processing Docker check scripts resolve the repo root via path (not `git rev-parse`) so worktree `git push` hooks find `processing.Dockerfile`

## Test plan
- [ ] Merge to `develop` → watch Deploy Staging for app + processing
- [ ] On staging: `docker compose ps app` healthy; `curl -sS -o /dev/null -w '%{http_code}\n' https://staging.tilda-geo.de/` → 200
- [ ] (Optional) Trigger processing while restarting app and confirm hook retries in logs


Made with [Cursor](https://cursor.com)