### PR TITLE
Map: optional 3D terrain, buildings, and elevation profile

### DIFF
--- a/app/src/components/regionen/pageRegionSlug/Map/Map3dTouchRotation.tsx
+++ b/app/src/components/regionen/pageRegionSlug/Map/Map3dTouchRotation.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from 'react'
+import { useMap } from 'react-map-gl/maplibre'
+import { useBg3dParam } from '@/components/regionen/pageRegionSlug/hooks/useQueryState/useBg3dParam'
+
+export const Map3dTouchRotation = () => {
+  const { mainMap } = useMap()
+  const { is3dActive } = useBg3dParam()
+
+  useEffect(
+    function syncTouchRotationWith3dMode() {
+      const map = mainMap?.getMap()
+      if (!map) return
+
+      if (is3dActive) {
+        map.touchZoomRotate.enableRotation()
+      } else {
+        map.touchZoomRotate.disableRotation()
+      }
+    },
+    [is3dActive, mainMap],
+  )
+
+  return null
+}

--- a/app/src/components/regionen/pageRegionSlug/Map/RegionMap.tsx
+++ b/app/src/components/regionen/pageRegionSlug/Map/RegionMap.tsx
@@ -14,6 +14,7 @@ import {
   useMapCalculatorDrawActive,
   useMapInspectorFeatures,
 } from '@/components/regionen/pageRegionSlug/hooks/mapState/useMapState'
+import { useBg3dParam } from '@/components/regionen/pageRegionSlug/hooks/useQueryState/useBg3dParam'
 import {
   convertToUrlFeature,
   isPersistableFeature,
@@ -37,15 +38,19 @@ import { MAP_STYLE_URL } from '@/server/api/map-style/mapStyleUrl.const'
 import { SIMPLIFY_MIN_ZOOM } from '@/server/instrumentation/generalization.const'
 import { useRegion } from '../regionUtils/useRegion'
 import { Calculator } from './Calculator/Calculator'
+import { Map3dTouchRotation } from './Map3dTouchRotation'
 import { QaZoomNotice } from './QaZoomNotice'
+import { ResetCameraWhen3dDisabled } from './ResetCameraWhen3dDisabled'
 import { SearchResultLayers } from './Search/SearchResultLayers'
 import { SourcesLayerRasterBackgrounds } from './SourcesAndLayers/SourcesLayerRasterBackgrounds'
 import { SourcesLayersAtlasGeo } from './SourcesAndLayers/SourcesLayersAtlasGeo'
 import { SourcesLayersInternalNotes } from './SourcesAndLayers/SourcesLayersInternalNotes'
+import { SourcesLayersMap3d, MAPTERHORN_DEM_SOURCE_ID } from './SourcesAndLayers/SourcesLayersMap3d'
 import { SourcesLayersOsmNotes } from './SourcesAndLayers/SourcesLayersOsmNotes'
 import { SourcesLayersQa } from './SourcesAndLayers/SourcesLayersQa'
 import { SourcesLayersStaticDatasets } from './SourcesAndLayers/SourcesLayersStaticDatasets'
 import { SourcesLayersSystemDatasets } from './SourcesAndLayers/SourcesLayersSystemDatasets'
+import { TerrainProfileHoverMarkerLayer } from './SourcesAndLayers/TerrainProfileHoverMarkerLayer'
 import { UpdateFeatureState } from './UpdateFeatureState'
 import { MASK_INTERACTIVE_LAYER_IDS } from './utils/maskLayerUtils'
 import { safeSetFeatureState } from './utils/safeSetFeatureState'
@@ -72,6 +77,7 @@ const NO_INTERACTIVE_LAYERS: string[] = []
 
 export const RegionMap = () => {
   const { mapParam, setMapParam } = useMapParam()
+  const { is3dActive, is3dTerrainActive } = useBg3dParam()
   const { setFeaturesParam } = useFeaturesParam()
   const {
     replaceInspectorFeatures,
@@ -191,8 +197,9 @@ export const RegionMap = () => {
   }
 
   const handleLoad = (event: MapLibreEvent) => {
-    // We disable rotation once after map startup to keep interactions consistent.
-    event.target.touchZoomRotate.disableRotation()
+    if (!is3dActive) {
+      event.target.touchZoomRotate.disableRotation()
+    }
 
     // Only when `loaded` all `Map` feature are actually usable (https://github.com/visgl/react-map-gl/issues/2123)
     markMapLoaded()
@@ -224,8 +231,13 @@ export const RegionMap = () => {
 
   const handleMoveEnd = (event: ViewStateChangeEvent) => {
     // Note: <SourcesAndLayersOsmNotes> simulates a moveEnd by watching the lat/lng url params
-    const { latitude, longitude, zoom } = event.viewState
-    void setMapParam({ zoom, lat: latitude, lng: longitude }, { history: 'replace' })
+    const { latitude, longitude, zoom, bearing, pitch } = event.viewState
+    const nextMapParam: MapParam = { zoom, lat: latitude, lng: longitude }
+    if (is3dActive) {
+      nextMapParam.bearing = bearing
+      nextMapParam.pitch = pitch
+    }
+    void setMapParam(nextMapParam, { history: 'replace' })
     updateMapBounds(mainMap?.getBounds() || null)
   }
 
@@ -268,6 +280,8 @@ export const RegionMap = () => {
         longitude: mapParam.lng,
         latitude: mapParam.lat,
         zoom: mapParam.zoom,
+        bearing: mapParam.bearing ?? 0,
+        pitch: mapParam.pitch ?? 0,
       }}
       // We prevent users from zooming out too far which puts too much load on our vector tiles db
       {...mapMaxBoundsSettings}
@@ -287,26 +301,42 @@ export const RegionMap = () => {
       onData={startMapDataLoading}
       onIdle={finishMapDataLoading}
       doubleClickZoom={true}
-      dragRotate={false}
+      dragRotate={is3dActive}
+      terrain={
+        is3dTerrainActive ? { source: MAPTERHORN_DEM_SOURCE_ID, exaggeration: 1.5 } : undefined
+      }
+      sky={
+        is3dActive
+          ? {
+              'sky-type': 'atmosphere',
+              'sky-atmosphere-sun': [0.0, 90.0],
+              'sky-atmosphere-sun-intensity': 15,
+            }
+          : undefined
+      }
       minZoom={SIMPLIFY_MIN_ZOOM}
       attributionControl={false}
     >
       {/* Order: First Background Sources, then Vector Tile Sources */}
       <UpdateFeatureState />
       <SourcesLayerRasterBackgrounds />
+      <SourcesLayersMap3d />
       <SourcesLayersSystemDatasets />
       <SourcesLayersAtlasGeo />
       <SourcesLayersStaticDatasets />
       <SourcesLayersOsmNotes />
       <SourcesLayersInternalNotes />
       <SourcesLayersQa />
+      <TerrainProfileHoverMarkerLayer />
       <SearchResultLayers />
       <AttributionControl compact={true} position="bottom-left" />
 
-      {/* Zoom controls are hidden on mobile to keep the map clean (pinch-to-zoom remains). */}
-      {isSmBreakpointOrAbove && (
-        <NavigationControl showCompass={false /* TODO: See Story */} visualizePitch={true} />
+      {/* Desktop always gets zoom controls; mobile only when 3D is active (compass reset). */}
+      {(isSmBreakpointOrAbove || is3dActive) && (
+        <NavigationControl showCompass={is3dActive} visualizePitch={true} />
       )}
+      <Map3dTouchRotation />
+      <ResetCameraWhen3dDisabled />
       <Calculator />
       {/* <GeolocateControl /> */}
       {/* <ScaleControl /> */}

--- a/app/src/components/regionen/pageRegionSlug/Map/RegionMap.tsx
+++ b/app/src/components/regionen/pageRegionSlug/Map/RegionMap.tsx
@@ -21,7 +21,10 @@ import {
   useFeaturesParam,
 } from '@/components/regionen/pageRegionSlug/hooks/useQueryState/useFeaturesParam/useFeaturesParam'
 import { useMapParam } from '@/components/regionen/pageRegionSlug/hooks/useQueryState/useMapParam'
-import type { MapParam } from '@/components/regionen/pageRegionSlug/hooks/useQueryState/utils/mapParam'
+import {
+  hasNonNeutralCamera,
+  type MapParam,
+} from '@/components/regionen/pageRegionSlug/hooks/useQueryState/utils/mapParam'
 import { useRegionDatasetsQuery } from '@/components/regionen/pageRegionSlug/hooks/useRegionDataQueries'
 import {
   interactivityConfiguration,
@@ -236,6 +239,8 @@ export const RegionMap = () => {
     if (is3dActive) {
       nextMapParam.bearing = bearing
       nextMapParam.pitch = pitch
+    } else if (hasNonNeutralCamera({ zoom, lat: latitude, lng: longitude, bearing, pitch })) {
+      mainMap?.getMap().jumpTo({ bearing: 0, pitch: 0 })
     }
     void setMapParam(nextMapParam, { history: 'replace' })
     updateMapBounds(mainMap?.getBounds() || null)
@@ -280,8 +285,8 @@ export const RegionMap = () => {
         longitude: mapParam.lng,
         latitude: mapParam.lat,
         zoom: mapParam.zoom,
-        bearing: mapParam.bearing ?? 0,
-        pitch: mapParam.pitch ?? 0,
+        bearing: is3dActive ? (mapParam.bearing ?? 0) : 0,
+        pitch: is3dActive ? (mapParam.pitch ?? 0) : 0,
       }}
       // We prevent users from zooming out too far which puts too much load on our vector tiles db
       {...mapMaxBoundsSettings}

--- a/app/src/components/regionen/pageRegionSlug/Map/ResetCameraWhen3dDisabled.tsx
+++ b/app/src/components/regionen/pageRegionSlug/Map/ResetCameraWhen3dDisabled.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useRef } from 'react'
+import { useMap } from 'react-map-gl/maplibre'
+import { useBg3dParam } from '@/components/regionen/pageRegionSlug/hooks/useQueryState/useBg3dParam'
+import { useMapParam } from '@/components/regionen/pageRegionSlug/hooks/useQueryState/useMapParam'
+import { hasNonNeutralCamera } from '@/components/regionen/pageRegionSlug/hooks/useQueryState/utils/mapParam'
+
+export const ResetCameraWhen3dDisabled = () => {
+  const { mainMap } = useMap()
+  const { is3dActive } = useBg3dParam()
+  const { mapParam, setMapParam } = useMapParam()
+  const was3dActiveRef = useRef(is3dActive)
+
+  useEffect(
+    function resetCameraAndMapParamWhen3dDisabled() {
+      const was3dActive = was3dActiveRef.current
+      was3dActiveRef.current = is3dActive
+
+      if (!was3dActive || is3dActive) return
+
+      const map = mainMap?.getMap()
+      if (map) {
+        map.easeTo({ bearing: 0, pitch: 0, duration: 300 })
+      }
+
+      if (hasNonNeutralCamera(mapParam)) {
+        void setMapParam(
+          { zoom: mapParam.zoom, lat: mapParam.lat, lng: mapParam.lng },
+          { history: 'replace' },
+        )
+      }
+    },
+    [is3dActive, mainMap, mapParam, setMapParam],
+  )
+
+  return null
+}

--- a/app/src/components/regionen/pageRegionSlug/Map/ResetCameraWhen3dDisabled.tsx
+++ b/app/src/components/regionen/pageRegionSlug/Map/ResetCameraWhen3dDisabled.tsx
@@ -9,6 +9,27 @@ export const ResetCameraWhen3dDisabled = () => {
   const { is3dActive } = useBg3dParam()
   const { mapParam, setMapParam } = useMapParam()
   const was3dActiveRef = useRef(is3dActive)
+  const didNormalizeInactiveCameraRef = useRef(false)
+
+  useEffect(
+    function normalizeMapParamCameraWhen3dInactiveOnLoad() {
+      if (didNormalizeInactiveCameraRef.current || is3dActive) return
+      if (!hasNonNeutralCamera(mapParam)) return
+
+      didNormalizeInactiveCameraRef.current = true
+
+      const map = mainMap?.getMap()
+      if (map) {
+        map.jumpTo({ bearing: 0, pitch: 0 })
+      }
+
+      void setMapParam(
+        { zoom: mapParam.zoom, lat: mapParam.lat, lng: mapParam.lng },
+        { history: 'replace' },
+      )
+    },
+    [is3dActive, mainMap, mapParam, setMapParam],
+  )
 
   useEffect(
     function resetCameraAndMapParamWhen3dDisabled() {

--- a/app/src/components/regionen/pageRegionSlug/Map/SourcesAndLayers/SourcesLayersMap3d.tsx
+++ b/app/src/components/regionen/pageRegionSlug/Map/SourcesAndLayers/SourcesLayersMap3d.tsx
@@ -1,0 +1,44 @@
+import { Layer, Source } from 'react-map-gl/maplibre'
+import { useBg3dParam } from '@/components/regionen/pageRegionSlug/hooks/useQueryState/useBg3dParam'
+
+export const MAPTERHORN_DEM_SOURCE_ID = 'mapterhorn-dem'
+const MAP3D_BUILDINGS_LAYER_ID = 'tilda-3d-buildings'
+
+const BUILDINGS_BEFORE_ID = 'atlas-app-beforeid-below-roadname'
+
+export const SourcesLayersMap3d = () => {
+  const { is3dBuildingActive, is3dTerrainActive } = useBg3dParam()
+
+  if (!is3dBuildingActive && !is3dTerrainActive) return null
+
+  return (
+    <>
+      {is3dTerrainActive && (
+        <Source
+          id={MAPTERHORN_DEM_SOURCE_ID}
+          type="raster-dem"
+          url="https://tiles.mapterhorn.com/tilejson.json"
+          tileSize={512}
+          encoding="terrarium"
+          attribution='Terrain data by <a href="https://mapterhorn.com/" target="_blank" rel="noopener noreferrer">Mapterhorn</a>'
+        />
+      )}
+      {is3dBuildingActive && (
+        <Layer
+          id={MAP3D_BUILDINGS_LAYER_ID}
+          type="fill-extrusion"
+          source="openmaptiles"
+          source-layer="building"
+          minzoom={15}
+          beforeId={BUILDINGS_BEFORE_ID}
+          paint={{
+            'fill-extrusion-color': '#d4d4d8',
+            'fill-extrusion-height': ['get', 'render_height'],
+            'fill-extrusion-base': ['get', 'render_min_height'],
+            'fill-extrusion-opacity': 0.75,
+          }}
+        />
+      )}
+    </>
+  )
+}

--- a/app/src/components/regionen/pageRegionSlug/Map/SourcesAndLayers/TerrainProfileHoverMarkerLayer.tsx
+++ b/app/src/components/regionen/pageRegionSlug/Map/SourcesAndLayers/TerrainProfileHoverMarkerLayer.tsx
@@ -1,0 +1,57 @@
+import { useQueryClient } from '@tanstack/react-query'
+import { featureCollection, point } from '@turf/turf'
+import { Layer, Source } from 'react-map-gl/maplibre'
+import { useMapInspectorFeatures } from '@/components/regionen/pageRegionSlug/hooks/mapState/useMapState'
+import { useBg3dParam } from '@/components/regionen/pageRegionSlug/hooks/useQueryState/useBg3dParam'
+import {
+  terrainProfileGeometryFingerprint,
+  terrainProfileGeometryFromFeature,
+} from '@/components/regionen/pageRegionSlug/profile/geometry/terrainProfileGeometryFromFeature'
+import { useTerrainProfileHoverSampleIndex } from '@/components/regionen/pageRegionSlug/profile/state/terrain-profile-hover-store'
+import type { TerrainProfileData } from '@/components/regionen/pageRegionSlug/profile/types'
+import { terrainProfileQueryKey } from '@/components/regionen/pageRegionSlug/profile/ui/SelectedFeatureTerrainProfilePanel'
+
+const TERRAIN_PROFILE_HOVER_SOURCE_ID = 'terrain-profile-hover'
+const TERRAIN_PROFILE_HOVER_LAYER_ID = 'terrain-profile-hover-marker'
+
+export const TerrainProfileHoverMarkerLayer = () => {
+  const { is3dTerrainActive } = useBg3dParam()
+  const hoverSampleIndex = useTerrainProfileHoverSampleIndex()
+  const inspectorFeatures = useMapInspectorFeatures()
+  const queryClient = useQueryClient()
+
+  if (!is3dTerrainActive || hoverSampleIndex === null) return null
+
+  const eligibleFeature = inspectorFeatures.find(
+    (feature) => terrainProfileGeometryFromFeature(feature) !== null,
+  )
+  if (!eligibleFeature) return null
+
+  const geometry = terrainProfileGeometryFromFeature(eligibleFeature)
+  if (!geometry) return null
+
+  const profile = queryClient.getQueryData<TerrainProfileData>(
+    terrainProfileQueryKey(eligibleFeature, terrainProfileGeometryFingerprint(geometry)),
+  )
+  const sample = profile?.samples[hoverSampleIndex]
+  if (!sample) return null
+
+  const geojson = featureCollection([
+    point([sample.lng, sample.lat], { elevation: sample.elevationMeters }),
+  ])
+
+  return (
+    <Source id={TERRAIN_PROFILE_HOVER_SOURCE_ID} type="geojson" data={geojson}>
+      <Layer
+        id={TERRAIN_PROFILE_HOVER_LAYER_ID}
+        type="circle"
+        paint={{
+          'circle-radius': 7,
+          'circle-color': '#ca8a04',
+          'circle-stroke-color': '#ffffff',
+          'circle-stroke-width': 2,
+        }}
+      />
+    </Source>
+  )
+}

--- a/app/src/components/regionen/pageRegionSlug/SidebarInspector/Inspector.tsx
+++ b/app/src/components/regionen/pageRegionSlug/SidebarInspector/Inspector.tsx
@@ -4,6 +4,8 @@ import { useRegionDatasetsQuery } from '@/components/regionen/pageRegionSlug/hoo
 import { internalNotesSourceId } from '@/components/regionen/pageRegionSlug/Map/SourcesAndLayers/SourcesLayersInternalNotes'
 import { osmNotesSourceId } from '@/components/regionen/pageRegionSlug/Map/SourcesAndLayers/SourcesLayersOsmNotes'
 import { qaSourceId } from '@/components/regionen/pageRegionSlug/Map/SourcesAndLayers/SourcesLayersQa'
+import { isTerrainProfileEligibleFeature } from '../profile/geometry/terrainProfileGeometryFromFeature'
+import { SelectedFeatureTerrainProfilePanel } from '../profile/ui/SelectedFeatureTerrainProfilePanel'
 import { createInspectorFeatureKey } from '../utils/sourceKeyUtils/createInspectorFeatureKey'
 import { parseSourceKeyStaticDatasets } from '../utils/sourceKeyUtils/sourceKeyUtilsStaticDataset'
 import { InspectorFeatureInternalNote } from './InspectorFeatureInternalNote'
@@ -28,6 +30,7 @@ type Props = {
 
 export const Inspector = ({ features }: Props) => {
   const { data: regionDatasets } = useRegionDatasetsQuery()
+  const profileFeature = features.find((feature) => isTerrainProfileEligibleFeature(feature))
 
   return (
     <div className="space-y-4">
@@ -60,6 +63,8 @@ export const Inspector = ({ features }: Props) => {
 
         return <div key={key}>{content}</div>
       })}
+
+      {profileFeature && <SelectedFeatureTerrainProfilePanel feature={profileFeature} />}
 
       <ToolsMissingTranslations />
     </div>

--- a/app/src/components/regionen/pageRegionSlug/background/Background3dToggleRow.tsx
+++ b/app/src/components/regionen/pageRegionSlug/background/Background3dToggleRow.tsx
@@ -1,0 +1,44 @@
+type Props = {
+  id: string
+  checked: boolean
+  onChange: (checked: boolean) => void
+  label: string
+  description: string
+}
+
+export const Background3dToggleRow = ({ id, checked, onChange, label, description }: Props) => {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-md px-2 py-1.5 hover:bg-yellow-50">
+      <div className="min-w-0 text-sm">
+        <label id={`${id}-label`} htmlFor={id} className="font-medium text-gray-900">
+          {label}
+        </label>{' '}
+        <span id={`${id}-description`} className="text-gray-500">
+          {description}
+        </span>
+      </div>
+
+      <div
+        className={`group relative inline-flex w-11 shrink-0 rounded-full p-0.5 transition-colors duration-200 ease-in-out ${
+          checked ? 'bg-yellow-500' : 'bg-gray-200'
+        }`}
+      >
+        <span
+          className={`size-5 rounded-full bg-white shadow-xs ring-1 ring-gray-900/5 transition-transform duration-200 ease-in-out ${
+            checked ? 'translate-x-5' : 'translate-x-0'
+          }`}
+        />
+        <input
+          id={id}
+          name={id}
+          type="checkbox"
+          checked={checked}
+          onChange={(event) => onChange(event.target.checked)}
+          aria-labelledby={`${id}-label`}
+          aria-describedby={`${id}-description`}
+          className="absolute inset-0 size-full cursor-pointer appearance-none rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-yellow-500"
+        />
+      </div>
+    </div>
+  )
+}

--- a/app/src/components/regionen/pageRegionSlug/background/SelectBackground.tsx
+++ b/app/src/components/regionen/pageRegionSlug/background/SelectBackground.tsx
@@ -10,6 +10,7 @@ import {
   type BackgroundParam,
 } from '@/components/regionen/pageRegionSlug/hooks/useQueryState/backgroundParam.const'
 import { useBackgroundParam } from '@/components/regionen/pageRegionSlug/hooks/useQueryState/useBackgroundParam'
+import { useBg3dParam } from '@/components/regionen/pageRegionSlug/hooks/useQueryState/useBg3dParam'
 import { useRegionLoaderData } from '@/components/regionen/pageRegionSlug/hooks/useRegionLoaderData'
 import { sourcesBackgroundsRaster } from '@/components/regionen/pageRegionSlug/mapData/mapDataSources/sourcesBackgroundsRaster.const'
 import { useBreakpoint } from '@/components/shared/hooks/viewport/useBreakpoint'
@@ -18,11 +19,14 @@ import {
   mobileControlButtonActiveClassName,
   mobileControlButtonClassName,
 } from '../mobile/mobileControlButton.const'
+import { Background3dToggleRow } from './Background3dToggleRow'
 import { ListOption } from './ListOption'
 
 export const SelectBackground: React.FC = () => {
   const { mainMap } = useMap()
   const { backgroundParam, setBackgroundParam } = useBackgroundParam()
+  const { is3dBuildingActive, is3dTerrainActive, toggle3dBuildings, toggle3dTerrain } =
+    useBg3dParam()
   const { region } = useRegionLoaderData()
   const isSmBreakpointOrAbove = useBreakpoint('sm')
   const [sheetOpen, setSheetOpen] = useState(false)
@@ -42,6 +46,28 @@ export const SelectBackground: React.FC = () => {
 
   // Mobile: an icon button that opens the same options as a bottom sheet (consistent
   // with the other mobile controls), instead of the desktop dropdown.
+  const threeDOptionsSection = (
+    <div className="border-t border-gray-200 px-2 py-2">
+      <p className="px-1 pb-1 text-xs font-semibold tracking-wide text-gray-500 uppercase">
+        3D-Optionen
+      </p>
+      <Background3dToggleRow
+        id="bg3d-buildings"
+        checked={is3dBuildingActive}
+        onChange={toggle3dBuildings}
+        label="3D-Gebäude"
+        description="Vereinfachte 3D-Gebäude anzeigen"
+      />
+      <Background3dToggleRow
+        id="bg3d-terrain"
+        checked={is3dTerrainActive}
+        onChange={toggle3dTerrain}
+        label="Höhenrelief"
+        description="Höhenrelief/Höhenoberfläche anzeigen"
+      />
+    </div>
+  )
+
   if (!isSmBreakpointOrAbove) {
     const options: { value: BackgroundParam; name: string }[] = [
       ...backgrounds.map(({ id, name }) => ({ value: id, name })),
@@ -102,6 +128,7 @@ export const SelectBackground: React.FC = () => {
               })}
             </div>
           </div>
+          {threeDOptionsSection}
         </MobileBottomSheet>
       </section>
     )
@@ -134,6 +161,7 @@ export const SelectBackground: React.FC = () => {
           value={defaultBackgroundParam}
           name="Standard"
         />
+        {threeDOptionsSection}
       </ListboxOptions>
     </Listbox>
   )

--- a/app/src/components/regionen/pageRegionSlug/hooks/useQueryState/useBg3dParam.ts
+++ b/app/src/components/regionen/pageRegionSlug/hooks/useQueryState/useBg3dParam.ts
@@ -1,0 +1,37 @@
+import { getBg3dModulesFromSearch } from '@/shared/regionen/regionSearchSchemas'
+import { searchParamsRegistry } from '@/shared/regionen/searchParamsRegistry'
+import { useRegionSearchNavigation } from './useRegionSearchNavigation'
+import {
+  is3dActive as getIs3dActive,
+  is3dBuildingActive as getIs3dBuildingActive,
+  is3dTerrainActive as getIs3dTerrainActive,
+  serializeBg3dParam,
+  type Bg3dModule,
+} from './utils/bg3dParam'
+
+export const useBg3dParam = () => {
+  const { search, updateSearch } = useRegionSearchNavigation()
+  const bg3dModules = getBg3dModulesFromSearch(search)
+
+  const setBg3dModules = (modules: Bg3dModule[]) => {
+    updateSearch({ [searchParamsRegistry.bg3d]: serializeBg3dParam(modules) }, { replace: true })
+  }
+
+  const toggleBg3dModule = (module: Bg3dModule, active: boolean) => {
+    const next = active ? [...bg3dModules, module] : bg3dModules.filter((entry) => entry !== module)
+    setBg3dModules(next)
+  }
+
+  const toggle3dBuildings = (active: boolean) => toggleBg3dModule('buildings', active)
+  const toggle3dTerrain = (active: boolean) => toggleBg3dModule('terrain', active)
+
+  return {
+    bg3dModules,
+    setBg3dModules,
+    toggle3dBuildings,
+    toggle3dTerrain,
+    is3dBuildingActive: getIs3dBuildingActive(bg3dModules),
+    is3dTerrainActive: getIs3dTerrainActive(bg3dModules),
+    is3dActive: getIs3dActive(bg3dModules),
+  }
+}

--- a/app/src/components/regionen/pageRegionSlug/hooks/useQueryState/utils/bg3dParam.test.ts
+++ b/app/src/components/regionen/pageRegionSlug/hooks/useQueryState/utils/bg3dParam.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'vitest'
+import {
+  is3dActive,
+  is3dBuildingActive,
+  is3dTerrainActive,
+  parseBg3dParam,
+  serializeBg3dParam,
+} from './bg3dParam'
+
+describe('parseBg3dParam()', () => {
+  test('parses CSV modules in canonical order', () => {
+    expect(parseBg3dParam('terrain,buildings')).toEqual(['buildings', 'terrain'])
+    expect(parseBg3dParam('buildings,terrain')).toEqual(['buildings', 'terrain'])
+  })
+
+  test('dedupes modules', () => {
+    expect(parseBg3dParam('buildings,buildings,terrain')).toEqual(['buildings', 'terrain'])
+  })
+
+  test('filters unknown values', () => {
+    expect(parseBg3dParam('buildings,foo,terrain,bar')).toEqual(['buildings', 'terrain'])
+  })
+
+  test('returns empty for missing or empty input', () => {
+    expect(parseBg3dParam(undefined)).toEqual([])
+    expect(parseBg3dParam('')).toEqual([])
+    expect(parseBg3dParam(' , ')).toEqual([])
+  })
+})
+
+describe('serializeBg3dParam()', () => {
+  test('serializes canonical order', () => {
+    expect(serializeBg3dParam(['terrain', 'buildings'])).toBe('buildings,terrain')
+  })
+
+  test('omits empty modules', () => {
+    expect(serializeBg3dParam([])).toBeUndefined()
+  })
+})
+
+describe('bg3d helper booleans', () => {
+  test('reflects active modules', () => {
+    const modules = parseBg3dParam('terrain')
+    expect(is3dBuildingActive(modules)).toBe(false)
+    expect(is3dTerrainActive(modules)).toBe(true)
+    expect(is3dActive(modules)).toBe(true)
+  })
+})

--- a/app/src/components/regionen/pageRegionSlug/hooks/useQueryState/utils/bg3dParam.ts
+++ b/app/src/components/regionen/pageRegionSlug/hooks/useQueryState/utils/bg3dParam.ts
@@ -1,0 +1,34 @@
+const BG3D_MODULES = ['buildings', 'terrain'] as const
+
+export type Bg3dModule = (typeof BG3D_MODULES)[number]
+
+const BG3D_MODULE_SET = new Set<string>(BG3D_MODULES)
+
+export const parseBg3dParam = (query: string | undefined | null): Bg3dModule[] => {
+  if (!query) return []
+  const seen = new Set<Bg3dModule>()
+  const modules: Bg3dModule[] = []
+
+  for (const part of query.split(',')) {
+    const trimmed = part.trim()
+    if (!BG3D_MODULE_SET.has(trimmed)) continue
+    const module = trimmed as Bg3dModule
+    if (seen.has(module)) continue
+    seen.add(module)
+    modules.push(module)
+  }
+
+  return modules.sort((a, b) => BG3D_MODULES.indexOf(a) - BG3D_MODULES.indexOf(b))
+}
+
+export const serializeBg3dParam = (modules: Bg3dModule[]): string | undefined => {
+  const canonical = parseBg3dParam(modules.join(','))
+  if (canonical.length === 0) return undefined
+  return canonical.join(',')
+}
+
+export const is3dBuildingActive = (modules: Bg3dModule[]) => modules.includes('buildings')
+
+export const is3dTerrainActive = (modules: Bg3dModule[]) => modules.includes('terrain')
+
+export const is3dActive = (modules: Bg3dModule[]) => modules.length > 0

--- a/app/src/components/regionen/pageRegionSlug/hooks/useQueryState/utils/mapParam.test.ts
+++ b/app/src/components/regionen/pageRegionSlug/hooks/useQueryState/utils/mapParam.test.ts
@@ -1,9 +1,47 @@
 import { describe, expect, test } from 'vitest'
-import { parseMapParam } from './mapParam'
+import { parseMapParam, serializeMapParam } from './mapParam'
 
 describe('parseMapParam()', () => {
-  test('Test parseMapParam()', () => {
+  test('parses 3-part map param', () => {
     expect(parseMapParam('13/48.1/9.2')).toStrictEqual({ zoom: 13, lat: 48.1, lng: 9.2 })
+  })
+
+  test('parses 4-part map param with bearing only', () => {
+    expect(parseMapParam('13/48.1/9.2/45')).toStrictEqual({
+      zoom: 13,
+      lat: 48.1,
+      lng: 9.2,
+      bearing: 45,
+    })
+  })
+
+  test('parses 5-part map param with bearing and pitch', () => {
+    expect(parseMapParam('13/48.1/9.2/45/60')).toStrictEqual({
+      zoom: 13,
+      lat: 48.1,
+      lng: 9.2,
+      bearing: 45,
+      pitch: 60,
+    })
+  })
+
+  test('falls back to core triplet on invalid trailing camera values', () => {
+    expect(parseMapParam('13/48.1/9.2/foo')).toStrictEqual({ zoom: 13, lat: 48.1, lng: 9.2 })
+    expect(parseMapParam('13/48.1/9.2/45/foo')).toStrictEqual({
+      zoom: 13,
+      lat: 48.1,
+      lng: 9.2,
+      bearing: 45,
+    })
+  })
+
+  test('ignores placeholder camera fragments', () => {
+    expect(parseMapParam('13/48.1/9.2/0')).toStrictEqual({ zoom: 13, lat: 48.1, lng: 9.2 })
+    expect(parseMapParam('13/48.1/9.2/0/0')).toStrictEqual({ zoom: 13, lat: 48.1, lng: 9.2 })
+    expect(parseMapParam('13/48.1/9.2/none/none')).toStrictEqual({ zoom: 13, lat: 48.1, lng: 9.2 })
+  })
+
+  test('rejects invalid core map values', () => {
     expect(parseMapParam('some-string')).toBeNull()
     expect(parseMapParam('@52.8,13.6,12.5z')).toBeNull()
     expect(parseMapParam('@some-stringz')).toBeNull()
@@ -19,5 +57,49 @@ describe('parseMapParam()', () => {
     testLng('bar48')
     testLng('-180.1')
     testLng('180.1')
+  })
+})
+
+describe('serializeMapParam()', () => {
+  test('serializes neutral camera as 3-part', () => {
+    expect(serializeMapParam({ zoom: 13, lat: 48.1, lng: 9.2 })).toBe('13/48.1/9.2')
+    expect(serializeMapParam({ zoom: 13, lat: 48.1, lng: 9.2, bearing: 0, pitch: 0 })).toBe(
+      '13/48.1/9.2',
+    )
+  })
+
+  test('never serializes synthetic /0/0 placeholders', () => {
+    const neutralVariants = [
+      { zoom: 13, lat: 48.1, lng: 9.2 },
+      { zoom: 13, lat: 48.1, lng: 9.2, bearing: 0 },
+      { zoom: 13, lat: 48.1, lng: 9.2, pitch: 0 },
+      { zoom: 13, lat: 48.1, lng: 9.2, bearing: 0, pitch: 0 },
+    ] as const
+
+    for (const mapParam of neutralVariants) {
+      expect(serializeMapParam(mapParam)).toBe('13/48.1/9.2')
+      expect(serializeMapParam(mapParam)).not.toMatch(/\/0\/0$/)
+    }
+  })
+
+  test('serializes rotated-but-flat camera as bearing/0', () => {
+    expect(serializeMapParam({ zoom: 13, lat: 48.1, lng: 9.2, bearing: 45, pitch: 0 })).toBe(
+      '13/48.1/9.2/45/0',
+    )
+    expect(serializeMapParam({ zoom: 13, lat: 48.1, lng: 9.2, bearing: 45 })).toBe(
+      '13/48.1/9.2/45/0',
+    )
+  })
+
+  test('serializes bearing and pitch when both non-neutral', () => {
+    expect(serializeMapParam({ zoom: 13, lat: 48.1, lng: 9.2, bearing: 45, pitch: 60 })).toBe(
+      '13/48.1/9.2/45/60',
+    )
+  })
+
+  test('round-trips Rapid-like 4-part inbound URLs', () => {
+    const parsed = parseMapParam('13/48.1/9.2/45')
+    expect(parsed).not.toBeNull()
+    expect(serializeMapParam(parsed!)).toBe('13/48.1/9.2/45/0')
   })
 })

--- a/app/src/components/regionen/pageRegionSlug/hooks/useQueryState/utils/mapParam.ts
+++ b/app/src/components/regionen/pageRegionSlug/hooks/useQueryState/utils/mapParam.ts
@@ -6,18 +6,70 @@ export type MapParam = {
   zoom: number
   lat: number
   lng: number
+  bearing?: number
+  pitch?: number
 }
 
-const MapParamSchema = z.tuple([range(0, 22), range(-90, 90), range(-180, 180)])
+const NEUTRAL_CAMERA_EPSILON = 0.05
+
+const CoreMapParamSchema = z.tuple([range(0, 22), range(-90, 90), range(-180, 180)])
+const BearingSchema = range(-360, 360)
+const PitchSchema = range(0, 85)
+
+const isPlaceholderCameraValue = (value: string) => {
+  const normalized = value.trim().toLowerCase()
+  return normalized === '' || normalized === '0' || normalized === 'none'
+}
+
+const isNeutralBearing = (bearing: number) =>
+  Math.abs(bearing) < NEUTRAL_CAMERA_EPSILON ||
+  Math.abs(bearing - 360) < NEUTRAL_CAMERA_EPSILON ||
+  Math.abs(bearing + 360) < NEUTRAL_CAMERA_EPSILON
+
+const isNeutralPitch = (pitch: number) => Math.abs(pitch) < NEUTRAL_CAMERA_EPSILON
+
+const isNeutralCamera = ({ bearing, pitch }: MapParam) => {
+  const resolvedBearing = bearing ?? 0
+  const resolvedPitch = pitch ?? 0
+  return isNeutralBearing(resolvedBearing) && isNeutralPitch(resolvedPitch)
+}
+
+export const hasNonNeutralCamera = (mapParam: MapParam) => !isNeutralCamera(mapParam)
 
 export const parseMapParam = (query: string) => {
-  const parsed = MapParamSchema.safeParse(query.split('/'))
-  if (!parsed.success) return null
-  const [zoom, lat, lng] = parsed.data
-  return { zoom, lat, lng } satisfies MapParam
+  const parts = query.split('/')
+  const coreParsed = CoreMapParamSchema.safeParse(parts.slice(0, 3))
+  if (!coreParsed.success) return null
+
+  const [zoom, lat, lng] = coreParsed.data
+  const result: MapParam = { zoom, lat, lng }
+
+  if (parts.length === 3) return result
+
+  if (parts.length >= 4 && !isPlaceholderCameraValue(parts[3] ?? '')) {
+    const bearingParsed = BearingSchema.safeParse(parts[3])
+    if (!bearingParsed.success) return result
+    result.bearing = bearingParsed.data
+  }
+
+  if (parts.length >= 5 && !isPlaceholderCameraValue(parts[4] ?? '')) {
+    const pitchParsed = PitchSchema.safeParse(parts[4])
+    if (!pitchParsed.success) return result
+    result.pitch = pitchParsed.data
+  }
+
+  return result
 }
 
-export const serializeMapParam = ({ zoom, lat, lng }: MapParam) => {
+const roundCameraValue = (value: number) => Number.parseFloat(value.toFixed(1))
+
+export const serializeMapParam = ({ zoom, lat, lng, bearing, pitch }: MapParam) => {
   const [roundedLat, roundedLng, roundedZoom] = roundPositionForURL(lat, lng, zoom)
-  return `${roundedZoom}/${roundedLat}/${roundedLng}`
+  let serialized = `${roundedZoom}/${roundedLat}/${roundedLng}`
+
+  if (!isNeutralCamera({ zoom, lat, lng, bearing, pitch })) {
+    serialized += `/${roundCameraValue(bearing ?? 0)}/${roundCameraValue(pitch ?? 0)}`
+  }
+
+  return serialized
 }

--- a/app/src/components/regionen/pageRegionSlug/profile/compose/buildTerrainProfileData.ts
+++ b/app/src/components/regionen/pageRegionSlug/profile/compose/buildTerrainProfileData.ts
@@ -1,0 +1,57 @@
+import { length, lineString } from '@turf/turf'
+import { sampleLineForTerrainProfile } from '../sampling/sampleLineForTerrainProfile'
+import { sampleTerrainElevations } from '../sampling/terrainSampler'
+import type { TerrainProfileData, TerrainProfileLine, TerrainProfileStats } from '../types'
+
+const buildStats = (samples: TerrainProfileData['samples'], distanceMeters: number) => {
+  let minElevationMeters = Number.POSITIVE_INFINITY
+  let maxElevationMeters = Number.NEGATIVE_INFINITY
+  let ascentMeters = 0
+  let descentMeters = 0
+
+  for (let index = 0; index < samples.length; index += 1) {
+    const sample = samples[index]
+    if (!sample) continue
+    const elevation = sample.elevationMeters
+    minElevationMeters = Math.min(minElevationMeters, elevation)
+    maxElevationMeters = Math.max(maxElevationMeters, elevation)
+
+    if (index === 0) continue
+    const previous = samples[index - 1]
+    if (!previous) continue
+    const delta = elevation - previous.elevationMeters
+    if (delta > 0) ascentMeters += delta
+    if (delta < 0) descentMeters += Math.abs(delta)
+  }
+
+  return {
+    minElevationMeters,
+    maxElevationMeters,
+    ascentMeters,
+    descentMeters,
+    distanceMeters,
+  } satisfies TerrainProfileStats
+}
+
+export const buildTerrainProfileData = async (
+  geometry: TerrainProfileLine,
+  options?: { featureLengthMeters?: number | null },
+) => {
+  const pathSamples = sampleLineForTerrainProfile(geometry)
+  const elevations = await sampleTerrainElevations(pathSamples)
+  const samples = pathSamples.map((sample, index) => ({
+    ...sample,
+    elevationMeters: elevations[index] ?? 0,
+  }))
+
+  const turfDistanceMeters = length(lineString(geometry.coordinates), { units: 'meters' })
+  const distanceMeters =
+    typeof options?.featureLengthMeters === 'number' && options.featureLengthMeters > 0
+      ? options.featureLengthMeters
+      : turfDistanceMeters
+
+  return {
+    samples,
+    stats: buildStats(samples, distanceMeters),
+  } satisfies TerrainProfileData
+}

--- a/app/src/components/regionen/pageRegionSlug/profile/compose/buildTerrainProfileData.ts
+++ b/app/src/components/regionen/pageRegionSlug/profile/compose/buildTerrainProfileData.ts
@@ -33,10 +33,7 @@ const buildStats = (samples: TerrainProfileData['samples'], distanceMeters: numb
   } satisfies TerrainProfileStats
 }
 
-export const buildTerrainProfileData = async (
-  geometry: TerrainProfileLine,
-  options?: { featureLengthMeters?: number | null },
-) => {
+export const buildTerrainProfileData = async (geometry: TerrainProfileLine) => {
   const pathSamples = sampleLineForTerrainProfile(geometry)
   const elevations = await sampleTerrainElevations(pathSamples)
   const samples = pathSamples.map((sample, index) => ({
@@ -44,11 +41,7 @@ export const buildTerrainProfileData = async (
     elevationMeters: elevations[index] ?? 0,
   }))
 
-  const turfDistanceMeters = length(lineString(geometry.coordinates), { units: 'meters' })
-  const distanceMeters =
-    typeof options?.featureLengthMeters === 'number' && options.featureLengthMeters > 0
-      ? options.featureLengthMeters
-      : turfDistanceMeters
+  const distanceMeters = length(lineString(geometry.coordinates), { units: 'meters' })
 
   return {
     samples,

--- a/app/src/components/regionen/pageRegionSlug/profile/geometry/terrainProfileGeometryFromFeature.test.ts
+++ b/app/src/components/regionen/pageRegionSlug/profile/geometry/terrainProfileGeometryFromFeature.test.ts
@@ -18,6 +18,39 @@ describe('terrainProfileGeometryFromFeature()', () => {
     expect(terrainProfileGeometryFromFeature(feature)).toStrictEqual(feature.geometry)
   })
 
+  test('picks the longest MultiLineString segment by geographic length', () => {
+    const feature = {
+      type: 'Feature' as const,
+      properties: {},
+      geometry: {
+        type: 'MultiLineString' as const,
+        coordinates: [
+          [
+            [9.0, 48.0],
+            [9.0001, 48.0],
+            [9.0001, 48.0001],
+            [9.0, 48.0001],
+            [9.0, 48.0],
+            [9.0001, 48.0],
+            [9.0001, 48.0001],
+          ],
+          [
+            [9.0, 48.0],
+            [9.01, 48.0],
+          ],
+        ],
+      },
+    }
+
+    expect(terrainProfileGeometryFromFeature(feature)).toStrictEqual({
+      type: 'LineString',
+      coordinates: [
+        [9.0, 48.0],
+        [9.01, 48.0],
+      ],
+    })
+  })
+
   test('returns null for non-line geometries', () => {
     const pointFeature = {
       type: 'Feature' as const,

--- a/app/src/components/regionen/pageRegionSlug/profile/geometry/terrainProfileGeometryFromFeature.test.ts
+++ b/app/src/components/regionen/pageRegionSlug/profile/geometry/terrainProfileGeometryFromFeature.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'vitest'
+import { terrainProfileGeometryFromFeature } from './terrainProfileGeometryFromFeature'
+
+describe('terrainProfileGeometryFromFeature()', () => {
+  test('returns LineString geometry unchanged', () => {
+    const feature = {
+      type: 'Feature' as const,
+      properties: {},
+      geometry: {
+        type: 'LineString' as const,
+        coordinates: [
+          [9.0, 48.0],
+          [9.1, 48.1],
+        ],
+      },
+    }
+
+    expect(terrainProfileGeometryFromFeature(feature)).toStrictEqual(feature.geometry)
+  })
+
+  test('returns null for non-line geometries', () => {
+    const pointFeature = {
+      type: 'Feature' as const,
+      properties: {},
+      geometry: {
+        type: 'Point' as const,
+        coordinates: [9.0, 48.0],
+      },
+    }
+
+    expect(terrainProfileGeometryFromFeature(pointFeature)).toBeNull()
+  })
+})

--- a/app/src/components/regionen/pageRegionSlug/profile/geometry/terrainProfileGeometryFromFeature.ts
+++ b/app/src/components/regionen/pageRegionSlug/profile/geometry/terrainProfileGeometryFromFeature.ts
@@ -1,0 +1,42 @@
+import { flatten } from '@turf/turf'
+import type { Feature, LineString } from 'geojson'
+import type { TerrainProfileLine } from '../types'
+
+export const terrainProfileGeometryFromFeature = (feature: Feature) => {
+  const geometry = feature.geometry
+  if (geometry?.type !== 'LineString' && geometry?.type !== 'MultiLineString') {
+    return null
+  }
+
+  if (geometry.type === 'LineString') {
+    return geometry satisfies TerrainProfileLine
+  }
+
+  const flattened = flatten(feature)
+  const lineFeatures = flattened.features.filter(
+    (entry): entry is Feature<LineString> => entry.geometry.type === 'LineString',
+  )
+  if (lineFeatures.length === 0) return null
+
+  const firstLine = lineFeatures[0]
+  if (!firstLine) return null
+
+  let longest: LineString = firstLine.geometry
+  let longestLength = longest.coordinates.length
+
+  for (const lineFeature of lineFeatures.slice(1)) {
+    const coordinateCount = lineFeature.geometry.coordinates.length
+    if (coordinateCount > longestLength) {
+      longest = lineFeature.geometry
+      longestLength = coordinateCount
+    }
+  }
+
+  return longest satisfies TerrainProfileLine
+}
+
+export const terrainProfileGeometryFingerprint = (geometry: TerrainProfileLine) =>
+  JSON.stringify(geometry.coordinates)
+
+export const isTerrainProfileEligibleFeature = (feature: Feature) =>
+  terrainProfileGeometryFromFeature(feature) !== null

--- a/app/src/components/regionen/pageRegionSlug/profile/geometry/terrainProfileGeometryFromFeature.ts
+++ b/app/src/components/regionen/pageRegionSlug/profile/geometry/terrainProfileGeometryFromFeature.ts
@@ -1,4 +1,4 @@
-import { flatten } from '@turf/turf'
+import { flatten, length, lineString } from '@turf/turf'
 import type { Feature, LineString } from 'geojson'
 import type { TerrainProfileLine } from '../types'
 
@@ -22,13 +22,15 @@ export const terrainProfileGeometryFromFeature = (feature: Feature) => {
   if (!firstLine) return null
 
   let longest: LineString = firstLine.geometry
-  let longestLength = longest.coordinates.length
+  let longestLengthMeters = length(lineString(longest.coordinates), { units: 'meters' })
 
   for (const lineFeature of lineFeatures.slice(1)) {
-    const coordinateCount = lineFeature.geometry.coordinates.length
-    if (coordinateCount > longestLength) {
+    const segmentLengthMeters = length(lineString(lineFeature.geometry.coordinates), {
+      units: 'meters',
+    })
+    if (segmentLengthMeters > longestLengthMeters) {
       longest = lineFeature.geometry
-      longestLength = coordinateCount
+      longestLengthMeters = segmentLengthMeters
     }
   }
 

--- a/app/src/components/regionen/pageRegionSlug/profile/sampling/sampleLineForTerrainProfile.ts
+++ b/app/src/components/regionen/pageRegionSlug/profile/sampling/sampleLineForTerrainProfile.ts
@@ -1,0 +1,57 @@
+import { along, length, lineString } from '@turf/turf'
+import type { TerrainProfileLine } from '../types'
+
+const DEFAULT_SAMPLE_SPACING_METERS = 10
+const MIN_SAMPLE_COUNT = 10
+const MAX_SAMPLE_COUNT = 320
+const DENSE_SAMPLING_THRESHOLD_METERS = 2000
+const LONG_DISTANCE_SAMPLE_TARGET = 200
+
+type TerrainProfilePathSample = {
+  lng: number
+  lat: number
+  distanceMeters: number
+}
+
+const resolveSpacingMeters = (distanceMeters: number, spacingMeters: number) => {
+  if (distanceMeters <= DENSE_SAMPLING_THRESHOLD_METERS) return spacingMeters
+  return Math.max(spacingMeters, distanceMeters / LONG_DISTANCE_SAMPLE_TARGET)
+}
+
+const calculateSampleCount = (
+  distanceMeters: number,
+  spacingMeters = DEFAULT_SAMPLE_SPACING_METERS,
+  maxSamples = MAX_SAMPLE_COUNT,
+) => {
+  const effectiveSpacingMeters = resolveSpacingMeters(distanceMeters, spacingMeters)
+  const targetSampleCount = Math.ceil(distanceMeters / effectiveSpacingMeters) + 1
+  return Math.max(2, Math.min(maxSamples, Math.max(MIN_SAMPLE_COUNT, targetSampleCount)))
+}
+
+export const sampleLineForTerrainProfile = (
+  geometry: TerrainProfileLine,
+  options?: { spacingMeters?: number; maxSamples?: number },
+) => {
+  const line = lineString(geometry.coordinates)
+  const distanceMeters = length(line, { units: 'meters' })
+  const sampleCount = calculateSampleCount(
+    distanceMeters,
+    options?.spacingMeters,
+    options?.maxSamples,
+  )
+
+  const samples: TerrainProfilePathSample[] = []
+  for (let index = 0; index < sampleCount; index += 1) {
+    const ratio = sampleCount === 1 ? 0 : index / (sampleCount - 1)
+    const point = along(line, distanceMeters * ratio, { units: 'meters' })
+    const [lng, lat] = point.geometry.coordinates
+    if (lng === undefined || lat === undefined) continue
+    samples.push({
+      lng,
+      lat,
+      distanceMeters: distanceMeters * ratio,
+    })
+  }
+
+  return samples
+}

--- a/app/src/components/regionen/pageRegionSlug/profile/sampling/terrainSampler.ts
+++ b/app/src/components/regionen/pageRegionSlug/profile/sampling/terrainSampler.ts
@@ -1,0 +1,101 @@
+import { lonLatToTileSample, sampleTerrariumPixel } from './terrarium'
+
+const TILE_ZOOM = 13
+const TILE_SIZE = 512
+const TILE_ENDPOINT = 'https://tiles.mapterhorn.com'
+const TILE_CACHE_LIMIT = 64
+
+type TerrainTile = {
+  size: number
+  imageData: Uint8ClampedArray
+}
+
+const tileCache = new Map<string, Promise<TerrainTile>>()
+const cacheOrder: string[] = []
+
+const rememberCacheKey = (key: string) => {
+  const existingIndex = cacheOrder.indexOf(key)
+  if (existingIndex >= 0) cacheOrder.splice(existingIndex, 1)
+  cacheOrder.push(key)
+  while (cacheOrder.length > TILE_CACHE_LIMIT) {
+    const oldest = cacheOrder.shift()
+    if (oldest) tileCache.delete(oldest)
+  }
+}
+
+const createBitmap = async (blob: Blob) => {
+  if (typeof createImageBitmap === 'function') {
+    return createImageBitmap(blob, { colorSpaceConversion: 'none' })
+  }
+
+  return new Promise<HTMLImageElement>((resolve, reject) => {
+    const image = new Image()
+    image.onload = () => resolve(image)
+    image.onerror = () => reject(new Error('Tile-Bitmap konnte nicht dekodiert werden.'))
+    image.src = URL.createObjectURL(blob)
+  })
+}
+
+const createRasterCanvas = (width: number, height: number) => {
+  if (typeof OffscreenCanvas === 'function') {
+    return new OffscreenCanvas(width, height)
+  }
+  const canvas = document.createElement('canvas')
+  canvas.width = width
+  canvas.height = height
+  return canvas
+}
+
+const loadTile = async (zoom: number, tileX: number, tileY: number) => {
+  const response = await fetch(`${TILE_ENDPOINT}/${zoom}/${tileX}/${tileY}.webp`)
+  if (!response.ok) {
+    throw new Error(`Mapterhorn-Kachel ${zoom}/${tileX}/${tileY} konnte nicht geladen werden.`)
+  }
+
+  const blob = await response.blob()
+  const bitmap = await createBitmap(blob)
+  const canvas = createRasterCanvas(bitmap.width, bitmap.height)
+  const context = canvas.getContext('2d', { willReadFrequently: true })
+  if (!context) {
+    throw new Error('Terrain-Kachel konnte nicht gelesen werden.')
+  }
+
+  context.drawImage(bitmap, 0, 0)
+  const imageData = context.getImageData(0, 0, bitmap.width, bitmap.height).data
+
+  return {
+    size: bitmap.width,
+    imageData,
+  }
+}
+
+const getTileForCoordinate = async (lng: number, lat: number) => {
+  const { tileX, tileY } = lonLatToTileSample(lng, lat, TILE_ZOOM, TILE_SIZE)
+  const cacheKey = `${TILE_ZOOM}/${tileX}/${tileY}`
+  const cached = tileCache.get(cacheKey)
+  if (cached) return cached
+
+  const promise = loadTile(TILE_ZOOM, tileX, tileY)
+  tileCache.set(cacheKey, promise)
+  rememberCacheKey(cacheKey)
+  return promise
+}
+
+const sampleTerrainElevationAtPoint = async (lng: number, lat: number) => {
+  const tile = await getTileForCoordinate(lng, lat)
+  const { pixelX, pixelY } = lonLatToTileSample(lng, lat, TILE_ZOOM, tile.size)
+  return sampleTerrariumPixel(tile.imageData, tile.size, pixelX, pixelY)
+}
+
+export type TerrainPathSampleInput = {
+  lng: number
+  lat: number
+  distanceMeters: number
+}
+
+export const sampleTerrainElevations = async (samples: TerrainPathSampleInput[]) => {
+  const elevations = await Promise.all(
+    samples.map((sample) => sampleTerrainElevationAtPoint(sample.lng, sample.lat)),
+  )
+  return elevations
+}

--- a/app/src/components/regionen/pageRegionSlug/profile/sampling/terrainSampler.ts
+++ b/app/src/components/regionen/pageRegionSlug/profile/sampling/terrainSampler.ts
@@ -75,7 +75,12 @@ const getTileForCoordinate = async (lng: number, lat: number) => {
   const cached = tileCache.get(cacheKey)
   if (cached) return cached
 
-  const promise = loadTile(TILE_ZOOM, tileX, tileY)
+  const promise = loadTile(TILE_ZOOM, tileX, tileY).catch((error) => {
+    tileCache.delete(cacheKey)
+    const cacheIndex = cacheOrder.indexOf(cacheKey)
+    if (cacheIndex >= 0) cacheOrder.splice(cacheIndex, 1)
+    throw error
+  })
   tileCache.set(cacheKey, promise)
   rememberCacheKey(cacheKey)
   return promise

--- a/app/src/components/regionen/pageRegionSlug/profile/sampling/terrarium.ts
+++ b/app/src/components/regionen/pageRegionSlug/profile/sampling/terrarium.ts
@@ -1,0 +1,44 @@
+const decodeTerrariumElevation = (red: number, green: number, blue: number) =>
+  red * 256 + green + blue / 256 - 32768
+
+export const lonLatToTileSample = (lng: number, lat: number, zoom: number, tileSize: number) => {
+  const latitudeRadians = (lat * Math.PI) / 180
+  const scale = 2 ** zoom
+  const normalizedX = ((lng + 180) / 360) * scale
+  const normalizedY =
+    ((1 - Math.log(Math.tan(latitudeRadians) + 1 / Math.cos(latitudeRadians)) / Math.PI) / 2) *
+    scale
+
+  const tileX = Math.floor(normalizedX)
+  const tileY = Math.floor(normalizedY)
+  const pixelX = Math.min(tileSize - 1, Math.max(0, (normalizedX - tileX) * tileSize))
+  const pixelY = Math.min(tileSize - 1, Math.max(0, (normalizedY - tileY) * tileSize))
+
+  return { tileX, tileY, pixelX, pixelY }
+}
+
+export const sampleTerrariumPixel = (
+  imageData: Uint8ClampedArray,
+  tileSize: number,
+  pixelX: number,
+  pixelY: number,
+) => {
+  const x0 = Math.floor(pixelX)
+  const y0 = Math.floor(pixelY)
+  const x1 = Math.min(tileSize - 1, x0 + 1)
+  const y1 = Math.min(tileSize - 1, y0 + 1)
+  const xWeight = pixelX - x0
+  const yWeight = pixelY - y0
+
+  const readElevation = (x: number, y: number) => {
+    const offset = (y * tileSize + x) * 4
+    const red = imageData[offset] ?? 0
+    const green = imageData[offset + 1] ?? 0
+    const blue = imageData[offset + 2] ?? 0
+    return decodeTerrariumElevation(red, green, blue)
+  }
+
+  const top = readElevation(x0, y0) * (1 - xWeight) + readElevation(x1, y0) * xWeight
+  const bottom = readElevation(x0, y1) * (1 - xWeight) + readElevation(x1, y1) * xWeight
+  return top * (1 - yWeight) + bottom * yWeight
+}

--- a/app/src/components/regionen/pageRegionSlug/profile/state/terrain-profile-hover-store.ts
+++ b/app/src/components/regionen/pageRegionSlug/profile/state/terrain-profile-hover-store.ts
@@ -1,0 +1,23 @@
+import { create } from 'zustand'
+
+type TerrainProfileHoverStore = {
+  hoverSampleIndex: number | null
+  actions: {
+    setHoverSampleIndex: (index: number | null) => void
+    clearHoverSampleIndex: () => void
+  }
+}
+
+const useTerrainProfileHoverStore = create<TerrainProfileHoverStore>()((set) => ({
+  hoverSampleIndex: null,
+  actions: {
+    setHoverSampleIndex: (index) => set({ hoverSampleIndex: index }),
+    clearHoverSampleIndex: () => set({ hoverSampleIndex: null }),
+  },
+}))
+
+export const useTerrainProfileHoverSampleIndex = () =>
+  useTerrainProfileHoverStore((state) => state.hoverSampleIndex)
+
+export const useTerrainProfileHoverActions = () =>
+  useTerrainProfileHoverStore((state) => state.actions)

--- a/app/src/components/regionen/pageRegionSlug/profile/types.ts
+++ b/app/src/components/regionen/pageRegionSlug/profile/types.ts
@@ -1,0 +1,21 @@
+type TerrainProfileSample = {
+  lng: number
+  lat: number
+  distanceMeters: number
+  elevationMeters: number
+}
+
+export type TerrainProfileStats = {
+  minElevationMeters: number
+  maxElevationMeters: number
+  ascentMeters: number
+  descentMeters: number
+  distanceMeters: number
+}
+
+export type TerrainProfileData = {
+  samples: TerrainProfileSample[]
+  stats: TerrainProfileStats
+}
+
+export type TerrainProfileLine = GeoJSON.LineString

--- a/app/src/components/regionen/pageRegionSlug/profile/ui/SelectedFeatureTerrainProfilePanel.tsx
+++ b/app/src/components/regionen/pageRegionSlug/profile/ui/SelectedFeatureTerrainProfilePanel.tsx
@@ -1,0 +1,78 @@
+import { useQuery } from '@tanstack/react-query'
+import type { Feature } from 'geojson'
+import { useEffect } from 'react'
+import { useBg3dParam } from '@/components/regionen/pageRegionSlug/hooks/useQueryState/useBg3dParam'
+import { Disclosure } from '@/components/regionen/pageRegionSlug/SidebarInspector/Disclosure/Disclosure'
+import { buildTerrainProfileData } from '../compose/buildTerrainProfileData'
+import {
+  terrainProfileGeometryFingerprint,
+  terrainProfileGeometryFromFeature,
+} from '../geometry/terrainProfileGeometryFromFeature'
+import { useTerrainProfileHoverActions } from '../state/terrain-profile-hover-store'
+import { TerrainProfileChart } from './TerrainProfileChart'
+import { TerrainProfileStatsView } from './TerrainProfileStats'
+
+type Props = {
+  feature: Feature
+}
+
+const getFeatureLengthMeters = (feature: Feature) => {
+  const lengthValue = feature.properties?.length
+  if (typeof lengthValue === 'number' && lengthValue > 0) return lengthValue
+  if (typeof lengthValue === 'string') {
+    const parsed = Number.parseFloat(lengthValue)
+    if (Number.isFinite(parsed) && parsed > 0) return parsed
+  }
+  return null
+}
+
+export const terrainProfileQueryKey = (feature: Feature, geometryFingerprint: string) => [
+  'terrain-profile',
+  feature.id ?? feature.properties?.id ?? geometryFingerprint,
+  geometryFingerprint,
+]
+
+export const SelectedFeatureTerrainProfilePanel = ({ feature }: Props) => {
+  const { is3dTerrainActive } = useBg3dParam()
+  const { clearHoverSampleIndex } = useTerrainProfileHoverActions()
+  const geometry = terrainProfileGeometryFromFeature(feature)
+  const geometryFingerprint = geometry ? terrainProfileGeometryFingerprint(geometry) : ''
+
+  useEffect(
+    function clearTerrainProfileHoverOnFeatureChange() {
+      clearHoverSampleIndex()
+    },
+    [clearHoverSampleIndex, feature],
+  )
+
+  const query = useQuery({
+    queryKey: terrainProfileQueryKey(feature, geometryFingerprint),
+    queryFn: () =>
+      buildTerrainProfileData(geometry!, {
+        featureLengthMeters: getFeatureLengthMeters(feature),
+      }),
+    enabled: is3dTerrainActive && geometry !== null,
+    staleTime: 5 * 60 * 1000,
+  })
+
+  if (!is3dTerrainActive || !geometry) return null
+
+  return (
+    <Disclosure title="Höhenprofil" defaultOpen>
+      <div className="space-y-3 p-3">
+        {query.isLoading && <p className="text-sm text-gray-600">Höhenprofil wird geladen …</p>}
+        {query.isError && (
+          <p className="text-sm text-red-700">
+            Höhenprofil konnte nicht geladen werden. Bitte später erneut versuchen.
+          </p>
+        )}
+        {query.data && (
+          <>
+            <TerrainProfileChart profile={query.data} />
+            <TerrainProfileStatsView stats={query.data.stats} />
+          </>
+        )}
+      </div>
+    </Disclosure>
+  )
+}

--- a/app/src/components/regionen/pageRegionSlug/profile/ui/SelectedFeatureTerrainProfilePanel.tsx
+++ b/app/src/components/regionen/pageRegionSlug/profile/ui/SelectedFeatureTerrainProfilePanel.tsx
@@ -16,16 +16,6 @@ type Props = {
   feature: Feature
 }
 
-const getFeatureLengthMeters = (feature: Feature) => {
-  const lengthValue = feature.properties?.length
-  if (typeof lengthValue === 'number' && lengthValue > 0) return lengthValue
-  if (typeof lengthValue === 'string') {
-    const parsed = Number.parseFloat(lengthValue)
-    if (Number.isFinite(parsed) && parsed > 0) return parsed
-  }
-  return null
-}
-
 export const terrainProfileQueryKey = (feature: Feature, geometryFingerprint: string) => [
   'terrain-profile',
   feature.id ?? feature.properties?.id ?? geometryFingerprint,
@@ -47,10 +37,7 @@ export const SelectedFeatureTerrainProfilePanel = ({ feature }: Props) => {
 
   const query = useQuery({
     queryKey: terrainProfileQueryKey(feature, geometryFingerprint),
-    queryFn: () =>
-      buildTerrainProfileData(geometry!, {
-        featureLengthMeters: getFeatureLengthMeters(feature),
-      }),
+    queryFn: () => buildTerrainProfileData(geometry!),
     enabled: is3dTerrainActive && geometry !== null,
     staleTime: 5 * 60 * 1000,
   })

--- a/app/src/components/regionen/pageRegionSlug/profile/ui/TerrainProfileChart.tsx
+++ b/app/src/components/regionen/pageRegionSlug/profile/ui/TerrainProfileChart.tsx
@@ -1,0 +1,94 @@
+import { useRef } from 'react'
+import { useTerrainProfileHoverActions } from '../state/terrain-profile-hover-store'
+import type { TerrainProfileData } from '../types'
+
+type Props = {
+  profile: TerrainProfileData
+}
+
+const CHART_HEIGHT = 120
+const CHART_PADDING = { top: 8, right: 8, bottom: 20, left: 36 }
+
+export const TerrainProfileChart = ({ profile }: Props) => {
+  const svgRef = useRef<SVGSVGElement>(null)
+  const { setHoverSampleIndex, clearHoverSampleIndex } = useTerrainProfileHoverActions()
+  const { samples, stats } = profile
+
+  if (samples.length < 2) return null
+
+  const width = 320
+  const innerWidth = width - CHART_PADDING.left - CHART_PADDING.right
+  const innerHeight = CHART_HEIGHT - CHART_PADDING.top - CHART_PADDING.bottom
+  const elevationRange = Math.max(1, stats.maxElevationMeters - stats.minElevationMeters)
+  const maxDistance = samples[samples.length - 1]?.distanceMeters ?? 1
+
+  const points = samples
+    .map((sample) => {
+      const x = CHART_PADDING.left + (sample.distanceMeters / maxDistance) * innerWidth
+      const y =
+        CHART_PADDING.top +
+        innerHeight -
+        ((sample.elevationMeters - stats.minElevationMeters) / elevationRange) * innerHeight
+      return `${x},${y}`
+    })
+    .join(' ')
+
+  const handlePointerMove = (event: React.PointerEvent<SVGSVGElement>) => {
+    const svg = svgRef.current
+    if (!svg) return
+    const rect = svg.getBoundingClientRect()
+    const relativeX = event.clientX - rect.left - CHART_PADDING.left
+    const ratio = Math.min(1, Math.max(0, relativeX / innerWidth))
+    const targetDistance = ratio * maxDistance
+
+    let closestIndex = 0
+    let closestDistance = Number.POSITIVE_INFINITY
+    for (const [index, sample] of samples.entries()) {
+      const delta = Math.abs(sample.distanceMeters - targetDistance)
+      if (delta < closestDistance) {
+        closestDistance = delta
+        closestIndex = index
+      }
+    }
+
+    setHoverSampleIndex(closestIndex)
+  }
+
+  return (
+    <svg
+      ref={svgRef}
+      viewBox={`0 0 ${width} ${CHART_HEIGHT}`}
+      className="h-32 w-full touch-none"
+      role="img"
+      aria-label="Höhenprofil"
+      onPointerMove={handlePointerMove}
+      onPointerLeave={clearHoverSampleIndex}
+    >
+      <polyline fill="none" stroke="#ca8a04" strokeWidth="2" points={points} />
+      <line
+        x1={CHART_PADDING.left}
+        y1={CHART_PADDING.top + innerHeight}
+        x2={CHART_PADDING.left + innerWidth}
+        y2={CHART_PADDING.top + innerHeight}
+        stroke="#d1d5db"
+      />
+      <text x={CHART_PADDING.left} y={CHART_HEIGHT - 4} className="fill-gray-500 text-[10px]">
+        0 m
+      </text>
+      <text
+        x={CHART_PADDING.left + innerWidth}
+        y={CHART_HEIGHT - 4}
+        textAnchor="end"
+        className="fill-gray-500 text-[10px]"
+      >
+        {stats.distanceMeters.toFixed(0)} m
+      </text>
+      <text x={4} y={CHART_PADDING.top + 8} className="fill-gray-500 text-[10px]">
+        {stats.maxElevationMeters.toFixed(0)} m
+      </text>
+      <text x={4} y={CHART_PADDING.top + innerHeight} className="fill-gray-500 text-[10px]">
+        {stats.minElevationMeters.toFixed(0)} m
+      </text>
+    </svg>
+  )
+}

--- a/app/src/components/regionen/pageRegionSlug/profile/ui/TerrainProfileChart.tsx
+++ b/app/src/components/regionen/pageRegionSlug/profile/ui/TerrainProfileChart.tsx
@@ -37,7 +37,9 @@ export const TerrainProfileChart = ({ profile }: Props) => {
     const svg = svgRef.current
     if (!svg) return
     const rect = svg.getBoundingClientRect()
-    const relativeX = event.clientX - rect.left - CHART_PADDING.left
+    const scaleX = width / rect.width
+    const xInViewBox = (event.clientX - rect.left) * scaleX
+    const relativeX = xInViewBox - CHART_PADDING.left
     const ratio = Math.min(1, Math.max(0, relativeX / innerWidth))
     const targetDistance = ratio * maxDistance
 

--- a/app/src/components/regionen/pageRegionSlug/profile/ui/TerrainProfileStats.tsx
+++ b/app/src/components/regionen/pageRegionSlug/profile/ui/TerrainProfileStats.tsx
@@ -1,0 +1,32 @@
+import type { TerrainProfileStats } from '../types'
+
+type Props = {
+  stats: TerrainProfileStats
+}
+
+export const TerrainProfileStatsView = ({ stats }: Props) => {
+  return (
+    <dl className="grid grid-cols-2 gap-x-3 gap-y-1 text-xs text-gray-700">
+      <div>
+        <dt className="text-gray-500">Mindesthöhe</dt>
+        <dd className="font-medium">{stats.minElevationMeters.toFixed(1)} m</dd>
+      </div>
+      <div>
+        <dt className="text-gray-500">Maximalhöhe</dt>
+        <dd className="font-medium">{stats.maxElevationMeters.toFixed(1)} m</dd>
+      </div>
+      <div>
+        <dt className="text-gray-500">Anstieg</dt>
+        <dd className="font-medium">{stats.ascentMeters.toFixed(1)} m</dd>
+      </div>
+      <div>
+        <dt className="text-gray-500">Abstieg</dt>
+        <dd className="font-medium">{stats.descentMeters.toFixed(1)} m</dd>
+      </div>
+      <div className="col-span-2">
+        <dt className="text-gray-500">Strecke</dt>
+        <dd className="font-medium">{stats.distanceMeters.toFixed(1)} m</dd>
+      </div>
+    </dl>
+  )
+}

--- a/app/src/shared/regionen/regionSearchSchemas.ts
+++ b/app/src/shared/regionen/regionSearchSchemas.ts
@@ -8,6 +8,11 @@ import {
   jurlStringify,
 } from '@/components/regionen/pageRegionSlug/hooks/useQueryState/useCategoriesConfig/v1/jurlParseStringify'
 import {
+  parseBg3dParam,
+  serializeBg3dParam,
+  type Bg3dModule,
+} from '@/components/regionen/pageRegionSlug/hooks/useQueryState/utils/bg3dParam'
+import {
   parseMapParam,
   serializeMapParam,
   type MapParam,
@@ -90,6 +95,14 @@ const backgroundSearchParam = () =>
 
 const qaSearchParam = () => z.preprocess(normalizeQaSearchParam, z.string().default('').catch(''))
 
+const normalizeBg3dSearchParam = (raw: unknown) => {
+  const wire = optionalSearchString().safeParse(raw).data
+  return serializeBg3dParam(parseBg3dParam(wire)) ?? ''
+}
+
+const bg3dSearchParam = () =>
+  z.preprocess(normalizeBg3dSearchParam, z.string().default('').catch(''))
+
 export const regionDialogParamSchema = z.enum(['welcome', 'download', 'docs'])
 
 export type RegionDialogParam = z.infer<typeof regionDialogParamSchema>
@@ -100,6 +113,7 @@ export const regionSearchSchema = z.object({
   [searchParamsRegistry.data]: searchStringArray().default([]),
   [searchParamsRegistry.f]: optionalSearchString(),
   [searchParamsRegistry.bg]: backgroundSearchParam(),
+  [searchParamsRegistry.bg3d]: bg3dSearchParam(),
   [searchParamsRegistry.draw]: optionalSearchString(),
   [searchParamsRegistry.osmNotes]: searchBoolean(false),
   [searchParamsRegistry.osmNote]: optionalSearchString(),
@@ -135,4 +149,8 @@ export const getQaParamFromSearch = (search: RegionSearch): QaParamData => {
 
 export const getDrawAreasFromSearch = (search: RegionSearch): DrawArea[] => {
   return parseDrawParam(search[searchParamsRegistry.draw])
+}
+
+export const getBg3dModulesFromSearch = (search: RegionSearch): Bg3dModule[] => {
+  return parseBg3dParam(search[searchParamsRegistry.bg3d] || undefined)
 }

--- a/app/src/shared/regionen/searchParamsRegistry.ts
+++ b/app/src/shared/regionen/searchParamsRegistry.ts
@@ -4,6 +4,7 @@ export const searchParamsRegistry = {
   data: 'data',
   f: 'f', // selected features
   bg: 'bg',
+  bg3d: 'bg3d',
   draw: 'draw',
   osmNotes: 'osmNotes', // show osmNotes on the map
   osmNote: 'osmNote', // show new osmNotes dialogue


### PR DESCRIPTION
## Summary
- Rebuild of [#290](https://github.com/FixMyBerlin/tilda-geo/pull/290) against [private-issues#3303](https://github.com/FixMyBerlin/private-issues/issues/3303) and the background-3d-profile plan: shareable `bg3d` toggles for Höhenrelief and simplified 3D buildings in Hintergrundkarten → 3D-Optionen.
- Declarative MapLibre integration (Mapterhorn DEM + fill-extrusion buildings, sky/compass/rotation only when 3D is on) following react-map-gl skills — no imperative `addSource`/`addLayer`/`setTerrain`.
- Terrain-only Höhenprofil in the inspector for selected line features (Mapterhorn sampling, chart ↔ map hover), plus optional `map` bearing/pitch URL state.

## Why this replaces #290
PR #290 always-on 3D, imperative map mutations, MapTiler DEM for the map, and a monolithic elevation component. This branch implements the planned URL-gated modules, Mapterhorn for map + profile, and modular TILDA-shaped code.

## Test plan
- [ ] Open a region with `?bg3d=buildings,terrain` and confirm both toggles in Hintergrundkarten → 3D-Optionen (desktop + mobile sheet)
- [ ] Toggle modules independently; confirm drag-rotate + compass only when at least one module is on; camera resets when 3D is turned off
- [ ] Pitch/rotate → URL gets 5-part `map=…`; north-up/flat → 3-part again
- [ ] With Höhenrelief on, select a LineString feature → Höhenprofil panel; hover chart → marker on map
- [ ] Without Höhenrelief / non-line geometry → no profile panel
- [ ] Attribution shows Mapterhorn when terrain is active
- [ ] `bun run check` green

Ping https://github.com/FixMyBerlin/tilda-geo/pull/290
Ping https://github.com/FixMyBerlin/private-issues/issues/3303


Made with [Cursor](https://cursor.com)